### PR TITLE
Adding NodeConfig#initialize yield

### DIFF
--- a/lib/active_triples/node_config.rb
+++ b/lib/active_triples/node_config.rb
@@ -8,6 +8,7 @@ module ActiveTriples
       self.class_name = args.delete(:class_name)
       self.multivalue = args.delete(:multivalue) { true } 
       raise ArgumentError, "Invalid arguments for Rdf Node configuration: #{args} on #{predicate}" unless args.empty?
+      yield(self) if block_given?
     end
 
     def [](value)

--- a/lib/active_triples/properties.rb
+++ b/lib/active_triples/properties.rb
@@ -19,7 +19,7 @@ module ActiveTriples
     # @param [Hash]  opts for this property, must include a :predicate
     # @yield [index] index sets solr behaviors for the property
     def property(name, opts={}, &block)
-      self.config[name] = NodeConfig.new(name, opts[:predicate], opts.except(:predicate)).tap do |config|
+      self.config[name] = NodeConfig.new(name, opts[:predicate], opts.except(:predicate)) do |config|
         config.with_index(&block) if block_given?
       end
       behaviors = config[name].behaviors.flatten if config[name].behaviors and not config[name].behaviors.empty?


### PR DESCRIPTION
Instead of relying on the obtuse #tap method, allow for a block to be
passed to the NodeConfig#initiailize.
