### PR TITLE
Replacing destructive method call with idempotent

### DIFF
--- a/lib/active_triples/term.rb
+++ b/lib/active_triples/term.rb
@@ -42,9 +42,9 @@ module ActiveTriples
     end
 
     def build(attributes={})
-      new_subject = attributes.key?('id') ? attributes.delete('id') : RDF::Node.new
+      new_subject = attributes.fetch('id') { RDF::Node.new }
       make_node(new_subject).tap do |node|
-        node.attributes = attributes
+        node.attributes = attributes.except('id')
         if parent.kind_of? List::ListResource
           parent.list << node
         elsif node.kind_of? RDF::List


### PR DESCRIPTION
Instead of modifying the input hash by calling Hash#delete, prefer to
fetch the key (with a comparable default) and pass the options along
without the previously deleted key.
