### PR TITLE
Replacing Hash#delete with Hash#fetch

### DIFF
--- a/lib/active_triples/node_config.rb
+++ b/lib/active_triples/node_config.rb
@@ -3,11 +3,12 @@ module ActiveTriples
     attr_accessor :predicate, :term, :class_name, :type, :behaviors, :multivalue, :cast
 
     def initialize(term, predicate, args={})
+      args.assert_valid_keys(:class_name, :multivalue)
       self.term = term
       self.predicate = predicate
-      self.class_name = args.delete(:class_name)
-      self.multivalue = args.delete(:multivalue) { true }
-      self.cast = args.delete(:cast) { true }
+      self.class_name = args.fetch(:class_name) { default_class_name }
+      self.multivalue = args.fetch(:multivalue) { default_multivalue }
+      self.cast = args.fetch(:cast) { true }
       raise ArgumentError, "Invalid arguments for Rdf Node configuration: #{args} on #{predicate}" unless args.empty?
       yield(self) if block_given?
     end
@@ -36,6 +37,16 @@ module ActiveTriples
       yield iobj
       self.type = iobj.data_type
       self.behaviors = iobj.behaviors
+    end
+
+    private
+
+    def default_class_name
+      nil
+    end
+
+    def default_multivalue
+      true
     end
 
     # this enables a cleaner API for solr integration


### PR DESCRIPTION
Instead of using the destructive #delete and validation of the hash
size, prefer #fetch and #assert_valid_keys. This ensures that the
input, which could be reused, is not obliterated.

For example if you use Rails Object#with_options the delete could
unexpected consequences.

http://api.rubyonrails.org/classes/Object.html#method-i-with_options

@TODO?

Is the assert_valid_keys necessary? API found:

http://api.rubyonrails.org/classes/Hash.html#method-i-assert_valid_keys
