### PR TITLE
Add prefix_id to config

### DIFF
--- a/lib/active_triples/configurable.rb
+++ b/lib/active_triples/configurable.rb
@@ -8,12 +8,16 @@ module ActiveTriples
   #
   # Define properties at the class level with:
   #
-  #    configure base_uri: "http://oregondigital.org/resource/", repository: :default
-  # Available properties are base_uri, rdf_label, type, and repository
+  #    configure base_uri: "http://oregondigital.org/resource/", "prefix_id: "b", repository: :default
+  # Available properties are base_uri, prefix_id, rdf_label, type, and repository
   module Configurable
     extend Deprecation
 
     def base_uri
+      nil
+    end
+
+    def prefix_id
       nil
     end
 
@@ -54,6 +58,7 @@ module ActiveTriples
     def configure(options = {})
       {
         base_uri: options[:base_uri],
+        prefix_id: options[:prefix_id],
         rdf_label: options[:rdf_label],
         type: options[:type],
         repository: options[:repository]

--- a/lib/active_triples/resource.rb
+++ b/lib/active_triples/resource.rb
@@ -180,6 +180,14 @@ module ActiveTriples
       self.class.base_uri
     end
 
+    ##
+    # @return [String, nil] the characters to prepend to the id used
+    #    to build the full URI. `nil` if none used.
+    #    full URI = base_uri/prefix_id + id passed to new('id')
+    def prefix_id
+      self.class.prefix_id
+    end
+
     def type
       self.get_values(:type).to_a.map{|x| x.rdf_subject}
     end
@@ -499,7 +507,7 @@ module ActiveTriples
         uri_or_str = uri_or_str.to_s
         return RDF::Node(uri_or_str[2..-1]) if uri_or_str.start_with? '_:'
         return RDF::URI(uri_or_str) if RDF::URI(uri_or_str).valid? and (URI.scheme_list.include?(RDF::URI.new(uri_or_str).scheme.upcase) or RDF::URI.new(uri_or_str).scheme == 'info')
-        return RDF::URI(self.base_uri.to_s + (self.base_uri.to_s[-1,1] =~ /(\/|#)/ ? '' : '/') + uri_or_str) if base_uri && !uri_or_str.start_with?(base_uri.to_s)
+        return RDF::URI(self.base_uri.to_s + (self.base_uri.to_s[-1,1] =~ /(\/|#)/ ? '' : '/') + self.prefix_id.to_s + uri_or_str) if base_uri && !uri_or_str.start_with?(base_uri.to_s)
         raise RuntimeError, "could not make a valid RDF::URI from #{uri_or_str}"
       end
   end

--- a/spec/active_triples/configurable_spec.rb
+++ b/spec/active_triples/configurable_spec.rb
@@ -11,11 +11,15 @@ describe ActiveTriples::Configurable do
 
   describe '#configure' do
     before do
-      DummyConfigurable.configure base_uri: "http://example.org/base", type: RDF::RDFS.Class, rdf_label: RDF::DC.title
+      DummyConfigurable.configure base_uri: "http://example.org/base", prefix_id: 'b', type: RDF::RDFS.Class, rdf_label: RDF::DC.title
     end
 
     it 'should set a base uri' do
       expect(DummyConfigurable.base_uri).to eq "http://example.org/base"
+    end
+
+    it 'should set a prefix_id' do
+      expect(DummyConfigurable.prefix_id).to eq "b"
     end
 
     it 'should set an rdf_label' do

--- a/spec/active_triples/resource_spec.rb
+++ b/spec/active_triples/resource_spec.rb
@@ -433,6 +433,31 @@ describe ActiveTriples::Resource do
     end
   end
 
+  describe '#prefix_id' do
+    before do
+      class DummyResourceWithoutPrefix < ActiveTriples::Resource
+        configure :base_uri => 'http://example.org'
+      end
+      class DummyResourceWithPrefix < ActiveTriples::Resource
+        configure :base_uri => 'http://example.org', :prefix_id => 'b'
+      end
+    end
+    after do
+      Object.send(:remove_const, "DummyResourceWithoutPrefix") if Object
+      Object.send(:remove_const, "DummyResourceWithPrefix") if Object
+    end
+
+    it "should use base_uri to construct rdf_subject" do
+      # backward compatibility when prefix_id is not specified
+      d = DummyResourceWithoutPrefix.new('1')
+      expect(d.rdf_subject).to eq RDF::URI("http://example.org/1")
+    end
+    it "should use base_uri and prefix_id to construct rdf_subject" do
+      d = DummyResourceWithPrefix.new('1')
+      expect(d.rdf_subject).to eq RDF::URI("http://example.org/b1")
+    end
+  end
+
   describe '#solrize' do
     it 'should return a label for bnodes' do
       expect(subject.solrize).to eq subject.rdf_label


### PR DESCRIPTION
It is desired that all instances of a resource model have their IDs prefixed by the same set of characters. For example, a virtual collection model will always be prefixed by 'vc'. Creating an instance of the virtual collection model and passing in an id='123' will produce a full id='vc123'. This works in conjunction with base_uri to construct the full rdf_subject.

```
      class DummyResourceWithPrefix < ActiveTriples::Resource
        configure :base_uri => 'http://example.org', :prefix_id => 'b'
      end
      d = DummyResourceWithPrefix.new('1')
      d.rdf_subject.to_s
      # http://example.org/b1
```

NOTES:
- For backward compatibility, a prefix will not be added to the full generated rdf_subject, if no prefix_id is specified.
- When base_uri is not used to construct the rdf_subject, the prefix_id will not be used.
