### PR TITLE
Protect Term#rdf_subject

### DIFF
--- a/lib/active_triples/resource.rb
+++ b/lib/active_triples/resource.rb
@@ -316,8 +316,8 @@ module ActiveTriples
     def get_term(args)
       @term_cache ||= {}
       term = Term.new(self, args)
-      @term_cache["#{term.rdf_subject}/#{term.property}"] ||= term
-      @term_cache["#{term.rdf_subject}/#{term.property}"]
+      @term_cache["#{term.send(:rdf_subject)}/#{term.property}"] ||= term
+      @term_cache["#{term.send(:rdf_subject)}/#{term.property}"]
     end
 
     ##

--- a/lib/active_triples/term.rb
+++ b/lib/active_triples/term.rb
@@ -92,15 +92,6 @@ module ActiveTriples
       value_arguments.last
     end
 
-    def rdf_subject
-      raise ArgumentError, "wrong number of arguments (#{value_arguments.length} for 1-2)" if value_arguments.length < 1 || value_arguments.length > 2
-      if value_arguments.length > 1
-        value_arguments.first
-      else
-        parent.rdf_subject
-      end
-    end
-
     protected
 
       def node_cache
@@ -197,6 +188,15 @@ module ActiveTriples
         klass ||= Resource
         klass = ActiveTriples.class_from_string(klass, final_parent.class) if klass.kind_of? String
         klass
+      end
+
+      def rdf_subject
+        raise ArgumentError, "wrong number of arguments (#{value_arguments.length} for 1-2)" if value_arguments.length < 1 || value_arguments.length > 2
+        if value_arguments.length > 1
+          value_arguments.first
+        else
+          parent.rdf_subject
+        end
       end
 
   end

--- a/spec/active_triples/term_spec.rb
+++ b/spec/active_triples/term_spec.rb
@@ -11,7 +11,7 @@ describe ActiveTriples::Term do
     context "when term has 0 value arguments" do
       before { subject.value_arguments = double(length: 0) }
       it "should raise an error" do
-        expect { subject.rdf_subject }.to raise_error
+        expect { subject.send(:rdf_subject) }.to raise_error
       end
     end
     context "when term has 1 value argument" do
@@ -20,19 +20,22 @@ describe ActiveTriples::Term do
         subject.value_arguments = double(length: 1)
       end
       it "should call `rdf_subject' on the parent" do
-        expect(subject.rdf_subject).to eq "parent subject"
+        expect(subject.send(:rdf_subject) ).to eq "parent subject"
+      end
+      it " is a private method" do
+        expect { subject.rdf_subject }.to raise_error NoMethodError
       end
     end
     context "when term has 2 value arguments" do
       before { subject.value_arguments = double(length: 2, first: "first") }
       it "should return the first value argument" do
-        expect(subject.rdf_subject).to eq "first"
+        expect(subject.send(:rdf_subject) ).to eq "first"
       end
     end
     context "when term has 3 value arguments" do
       before { subject.value_arguments = double(length: 3) }
       it "should raise an error" do
-        expect { subject.rdf_subject }.to raise_error
+        expect { subject.send(:rdf_subject)  }.to raise_error
       end
     end
   end


### PR DESCRIPTION
Terms having public rdf_subjects created a pitfall users accidentally
trying to work with Terms instead of their member values. This tightens
up the API to prevent confusion.

Closes #56.

Ping @terrellt 
