### PR TITLE
Replacing Hash#delete with Hash#fetch

### DIFF
--- a/lib/active_triples/node_config.rb
+++ b/lib/active_triples/node_config.rb
@@ -5,8 +5,8 @@ module ActiveTriples
     def initialize(term, predicate, args={})
       self.term = term
       self.predicate = predicate
-      self.class_name = args.delete(:class_name)
-      self.cast = args.delete(:cast) { true }
+      self.class_name = args.fetch(:class_name) { default_class_name }
+      self.cast = args.fetch(:cast) { true }
       yield(self) if block_given?
     end
 
@@ -34,6 +34,12 @@ module ActiveTriples
       yield iobj
       self.type = iobj.data_type
       self.behaviors = iobj.behaviors
+    end
+
+    private
+
+    def default_class_name
+      nil
     end
 
     # this enables a cleaner API for solr integration


### PR DESCRIPTION
Instead of using the destructive #delete and validation of the hash
size, prefer #fetch and #assert_valid_keys. This ensures that the
input, which could be reused, is not obliterated.

For example if you use Rails Object#with_options the delete could
unexpected consequences.

http://api.rubyonrails.org/classes/Object.html#method-i-with_options

@TODO?

Is the assert_valid_keys necessary? API found:

http://api.rubyonrails.org/classes/Hash.html#method-i-assert_valid_keys
