### PR TITLE
Reject properties defined with no :predicate

### DIFF
--- a/lib/active_triples/property_builder.rb
+++ b/lib/active_triples/property_builder.rb
@@ -11,8 +11,11 @@ module ActiveTriples
     def self.create_builder(name, options, &block)
       raise ArgumentError, "property names must be a Symbol" unless
         name.kind_of?(Symbol)
-      raise ArgumentError, "must provide a :predicate" unless
-        options.keys.include? :predicate
+
+      options[:predicate] = RDF::Resource.new(options[:predicate])
+      raise ArgumentError, "must provide an RDF::Resource to :predicate" unless
+        options[:predicate].valid?
+
 
       new(name, options, &block)
     end
@@ -57,7 +60,9 @@ module ActiveTriples
     end
 
     def build(&block)
-      NodeConfig.new(name, options[:predicate], options.except(:predicate)) do |config|
+      NodeConfig.new(name,
+                     options[:predicate],
+                     options.except(:predicate)) do |config|
         config.with_index(&block) if block_given?
       end
     end

--- a/lib/active_triples/property_builder.rb
+++ b/lib/active_triples/property_builder.rb
@@ -9,7 +9,10 @@ module ActiveTriples
     end
 
     def self.create_builder(name, options, &block)
-      raise ArgumentError, "property names must be a Symbol" unless name.kind_of?(Symbol)
+      raise ArgumentError, "property names must be a Symbol" unless
+        name.kind_of?(Symbol)
+      raise ArgumentError, "must provide a :predicate" unless
+        options.keys.include? :predicate
 
       new(name, options, &block)
     end

--- a/spec/active_triples/properties_spec.rb
+++ b/spec/active_triples/properties_spec.rb
@@ -44,6 +44,10 @@ describe ActiveTriples::Properties do
       expect { DummyProperties.property :type, :predicate => RDF::DC.type }.to raise_error ArgumentError
     end
 
+    it 'raises error when defining properties with no predicate' do
+      expect { DummyProperties.property :type }.to raise_error ArgumentError
+    end
+
     it 'raises error when defining properties already have method setters' do
       DummyProperties.send :define_method, :type=, lambda { }
       expect { DummyProperties.property :type, :predicate => RDF::DC.type }.to raise_error ArgumentError

--- a/spec/active_triples/properties_spec.rb
+++ b/spec/active_triples/properties_spec.rb
@@ -12,9 +12,19 @@ describe ActiveTriples::Properties do
   end
 
   describe '#property' do
-    it 'should set a property' do
+    it 'should set a property as a NodeConfig' do
       DummyProperties.property :title, :predicate => RDF::DC.title
       expect(DummyProperties.reflect_on_property(:title)).to be_kind_of ActiveTriples::NodeConfig
+    end
+
+    it 'should set the correct property' do
+      DummyProperties.property :title, :predicate => RDF::DC.title
+      expect(DummyProperties.reflect_on_property(:title).predicate).to eql RDF::DC.title
+    end
+
+    it 'should set the correct property from string' do
+      DummyProperties.property :title, :predicate => RDF::DC.title.to_s
+      expect(DummyProperties.reflect_on_property(:title).predicate).to eql RDF::DC.title
     end
 
     it 'should set index behaviors' do
@@ -46,6 +56,10 @@ describe ActiveTriples::Properties do
 
     it 'raises error when defining properties with no predicate' do
       expect { DummyProperties.property :type }.to raise_error ArgumentError
+    end
+
+    it 'raises error when defining properties with a non-Roesource predicate' do
+      expect { DummyProperties.property :type, :predicate => 123 }.to raise_error ArgumentError
     end
 
     it 'raises error when defining properties already have method setters' do


### PR DESCRIPTION
Properties with no predicate previously acted as accessors on all predicates. This prevents them from being defined.

Closes #102.