### PR TITLE
Add tests and documentation for .class_from_string

### DIFF
--- a/lib/active_triples.rb
+++ b/lib/active_triples.rb
@@ -27,10 +27,30 @@ module ActiveTriples
   class RepositoryNotFoundError < StandardError
   end
 
+  ##
+  # Converts a string for a class or module into a a constant. This will find
+  # classes in or above a given container class.
+  #
+  # @example finding a class in Kernal
+  #    ActiveTriples.class_from_string('MyClass') # => MyClass
+  #
+  # @example finding a class in a module
+  #    ActiveTriples.class_from_string('MyClass', MyModule) 
+  #    # => MyModule::MyClass
+  #
+  # @example when a class exists above the module, but not in it
+  #    ActiveTriples.class_from_string('Object', MyModule) 
+  #    # => Object
+  #
+  # @param class_name [String]
+  # @param container_class
+  #
+  # @return [Class]
   def self.class_from_string(class_name, container_class=Kernel)
     container_class = container_class.name if container_class.is_a? Module
     container_parts = container_class.split('::')
-    (container_parts + class_name.split('::')).flatten.inject(Kernel) do |mod, class_name|
+    (container_parts + class_name.split('::'))
+      .flatten.inject(Kernel) do |mod, class_name|
       if mod == Kernel
         Object.const_get(class_name)
       elsif mod.const_defined? class_name.to_sym

--- a/spec/active_triples_spec.rb
+++ b/spec/active_triples_spec.rb
@@ -1,7 +1,56 @@
 require 'spec_helper'
 
 describe ActiveTriples do
-  describe '.ActiveTriples' do
+  describe '.class_from_string' do
+    before do
+      module TestModule
+        class TestClass; end
+      end
+
+      class TestBase; end
+    end
+    
+    after do
+      Object.send(:remove_const, :TestModule)
+      Object.send(:remove_const, :TestBase)
+    end
+
+    it 'converts classes in kernal' do
+      expect(subject.class_from_string('TestBase')).to eq TestBase
+    end
+
+    it 'raises an error when class is undefined' do
+      expect { subject.class_from_string('NotDefined') }
+        .to raise_error NameError
+    end
+
+    it 'converts classes in a module' do
+      expect(subject.class_from_string('TestClass', TestModule))
+        .to eq TestModule::TestClass
+    end
+
+    it 'finds class above selected module' do
+      expect(subject.class_from_string('Object', TestModule)).to eq Object
+    end
+
+    it 'raises an error when class is undefined in module' do
+      expect { subject.class_from_string('NotDefined', TestModule) }
+        .to raise_error NameError
+    end
+
+    it 'finds class above multiple selected modules' do
+      expect(subject.class_from_string('Object', 'TestModule::TestClass'))
+        .to eq Object
+    end
+
+    # is this the correct behavior!?
+    it 'climbs up nested module contexts' do
+      expect(subject.class_from_string('', 'TestModule::TestClass'))
+        .to eq TestModule::TestClass
+    end
+  end
+  
+  describe '.ActiveTripels' do
     it 'outputs a string' do
       expect { described_class.ActiveTripels }.to output.to_stdout
     end


### PR DESCRIPTION
This method was imported from ActiveFedora, and was undocumented. This should ensure it's better understood in this context.