### PR TITLE
Delete all values when emptying a Relation

### DIFF
--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -55,11 +55,13 @@ module ActiveTriples
       parent.persist! if parent.persistence_strategy.is_a? ParentStrategy
     end
 
+    ##
+    # Deletes the values for this relation. This removes all triples matching
+    # the basic graph pattern [:rdf_subject :predicate ?object] from the parent
+    # Enumerable.
     def empty_property
       parent.query([rdf_subject, predicate, nil]).each_statement do |statement|
-        if !uri_class(statement.object) || uri_class(statement.object) == class_for_property
-          parent.delete(statement)
-        end
+        parent.delete(statement)
       end
     end
 

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -146,6 +146,44 @@ describe ActiveTriples::RDFSource do
     it 'sets a value'
   end
 
+  describe "inheritance" do
+    before do
+      class PrincipalResource
+        include ActiveTriples::RDFSource
+
+        configure type: RDF::FOAF.Agent
+        property :name, predicate: RDF::FOAF.name
+      end
+
+      class UserSource < PrincipalResource
+        configure type: RDF::FOAF.Person
+      end
+
+      class DummySource
+        include ActiveTriples::RDFSource
+
+        property :creator, predicate: RDF::DC.creator
+      end
+    end
+
+    after do
+      Object.send(:remove_const, :PrincipalResource)
+      Object.send(:remove_const, :UserSource)
+      Object.send(:remove_const, :DummySource)
+    end
+
+    let(:dummy) { DummySource.new }
+    let(:bob) { UserSource.new.tap {|u| u.name = "bob"} }
+    let(:sally) { UserSource.new.tap {|u| u.name = "sally"} }
+
+    it "should replace values" do
+      dummy.creator = bob
+      expect(dummy.creator).to eq [bob]
+      dummy.creator = sally
+      expect(dummy.creator).to eq [sally]
+    end
+  end
+
   describe 'validation' do
     it { is_expected.to be_valid }
 


### PR DESCRIPTION
`Relations` used to try to limit their deletion of triples to a property-class pair. That idea never really panned out, this removes some of the problems caused by it. Especially, it closes #38 (at long last).

~~This needs to be rebased onto `develop` after #133 is merged. The relevant commit is 4f5ba7d.~~