### PR TITLE
Remove deprecated method and class

### DIFF
--- a/lib/active_triples.rb
+++ b/lib/active_triples.rb
@@ -29,7 +29,6 @@ module ActiveTriples
   extend ActiveSupport::Autoload
   eager_autoload do
     autoload :RDFSource
-
     autoload :Resource
     autoload :List
     autoload :Relation
@@ -51,11 +50,9 @@ module ActiveTriples
              'active_triples/persistence_strategies/parent_strategy'
     autoload :RepositoryStrategy,
              'active_triples/persistence_strategies/repository_strategy'
-
-    # deprecated class
-    autoload :Term, 'active_triples/relation'
   end
-
+  
+  ##
   # Raised when a declared repository doesn't have a definition
   class RepositoryNotFoundError < StandardError
   end
@@ -96,7 +93,7 @@ module ActiveTriples
   end
 
   ##
-  # A simplified, belgian version of this software
+  # A simplified, Belgian version of this software
   def self.ActiveTripels
     puts <<-eos
 
@@ -113,5 +110,4 @@ module ActiveTriples
 eos
 "Yum"
   end
-
 end

--- a/lib/active_triples/configurable.rb
+++ b/lib/active_triples/configurable.rb
@@ -30,13 +30,6 @@ module ActiveTriples
       @configuration ||= Configuration.new
     end
 
-    ##
-    # @deprecated use `configure type:` instead.
-    def rdf_type(value)
-      Deprecation.warn Configurable, "rdf_type is deprecated and will be removed in active-fedora 8.0.0. Use configure type: instead.", caller
-      configure type: value
-    end
-
     def repository
       configuration[:repository]
     end

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -242,18 +242,4 @@ module ActiveTriples
         end
       end
   end
-
-  class Term < Relation
-    def self.inherited(*)
-      warn 'ActiveTriples::Term is deprecated! ' \
-           'Use ActiveTriples::Relation instead.'
-      super
-    end
-
-    def initialize(*)
-      warn 'ActiveTriples::Term is deprecated! ' \
-           'Use ActiveTriples::Relation instead.'
-      super
-    end
-  end
 end

--- a/spec/active_triples/configurable_spec.rb
+++ b/spec/active_triples/configurable_spec.rb
@@ -1,10 +1,12 @@
 require "spec_helper"
+
 describe ActiveTriples::Configurable do
   before do
     class DummyConfigurable
       extend ActiveTriples::Configurable
     end
   end
+
   after do
     Object.send(:remove_const, "DummyConfigurable")
   end
@@ -12,10 +14,12 @@ describe ActiveTriples::Configurable do
   it "should be okay if not configured" do
     expect(DummyConfigurable.type).to eq nil
   end
+
   it "should be okay if configured to nil" do
     DummyConfigurable.configure :type => nil
     expect(DummyConfigurable.type).to eq []
   end
+
   describe '#configure' do
     before do
       DummyConfigurable.configure base_uri: "http://example.org/base", type: RDF::RDFS.Class, rdf_label: RDF::DC.title
@@ -37,18 +41,10 @@ describe ActiveTriples::Configurable do
     it 'should set a type' do
       expect(DummyConfigurable.type).to eq [RDF::RDFS.Class]
     end
+
     it "should be able to set multiple types" do
       DummyConfigurable.configure type: RDF::RDFS.Container
       expect(DummyConfigurable.type).to eq [RDF::RDFS.Class, RDF::RDFS.Container]
-    end
-  end
-
-  describe '#rdf_type' do
-    it "should set the type the old way" do
-      expect(DummyConfigurable).to receive(:configure).with(type: RDF::RDFS.Class).and_call_original
-      expect(Deprecation).to receive(:warn)
-      DummyConfigurable.rdf_type(RDF::RDFS.Class)
-      expect(DummyConfigurable.type).to eq [RDF::RDFS.Class]
     end
   end
 end


### PR DESCRIPTION
This removes `Term` which is replaced by `Relation`, and the old style of `rdf_type` configuration. Removal of these deprecations should be appropriate, since the refactor in #133 requires a minor version bump.