### PR TITLE
Remove unused method from `identifiable_spec.rb`

### DIFF
--- a/spec/active_triples/identifiable_spec.rb
+++ b/spec/active_triples/identifiable_spec.rb
@@ -3,24 +3,7 @@ require 'active_model'
 
 describe ActiveTriples::Identifiable do
   before do
-    class ActiveExample
-      include ActiveTriples::Identifiable
-
-      def self.property(*args)
-        prop = args.first
-
-        define_method prop.to_s do
-          resource.get_values(prop)
-        end
-
-        define_method "#{prop.to_s}=" do |*args|
-          resource.set_value(prop, *args)
-        end
-
-        resource_class.property(*args)
-      end
-
-    end
+    class ActiveExample; include ActiveTriples::Identifiable; end
   end
 
   after do


### PR DESCRIPTION
This method exists only for the test cases and is never called. Seems best to remove it.