### PR TITLE
Revert "Delete all values when emptying a relation"

### DIFF
--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -55,13 +55,11 @@ module ActiveTriples
       parent.persist! if parent.persistence_strategy.is_a? ParentStrategy
     end
 
-    ##
-    # Deletes the values for this relation. This removes all triples matching
-    # the basic graph pattern [:rdf_subject :predicate ?object] from the parent
-    # Enumerable.
     def empty_property
       parent.query([rdf_subject, predicate, nil]).each_statement do |statement|
-        parent.delete(statement)
+        if !uri_class(statement.object) || uri_class(statement.object) == class_for_property
+          parent.delete(statement)
+        end
       end
     end
 

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -146,44 +146,6 @@ describe ActiveTriples::RDFSource do
     it 'sets a value'
   end
 
-  describe "inheritance" do
-    before do
-      class PrincipalResource
-        include ActiveTriples::RDFSource
-
-        configure type: RDF::FOAF.Agent
-        property :name, predicate: RDF::FOAF.name
-      end
-
-      class UserSource < PrincipalResource
-        configure type: RDF::FOAF.Person
-      end
-
-      class DummySource
-        include ActiveTriples::RDFSource
-
-        property :creator, predicate: RDF::DC.creator
-      end
-    end
-
-    after do
-      Object.send(:remove_const, :PrincipalResource)
-      Object.send(:remove_const, :UserSource)
-      Object.send(:remove_const, :DummySource)
-    end
-
-    let(:dummy) { DummySource.new }
-    let(:bob) { UserSource.new.tap {|u| u.name = "bob"} }
-    let(:sally) { UserSource.new.tap {|u| u.name = "sally"} }
-
-    it "should replace values" do
-      dummy.creator = bob
-      expect(dummy.creator).to eq [bob]
-      dummy.creator = sally
-      expect(dummy.creator).to eq [sally]
-    end
-  end
-
   describe 'validation' do
     it { is_expected.to be_valid }
 

--- a/spec/active_triples/relation_spec.rb
+++ b/spec/active_triples/relation_spec.rb
@@ -3,10 +3,6 @@ require 'rdf/isomorphic'
 
 describe ActiveTriples::Relation do
 
-  subject do
-    described_class.new(double("parent", reflections: []), double("value args"))
-  end
-
   describe "#rdf_subject" do
     let(:parent_resource) { double("parent resource", reflections: {}) }
 
@@ -45,51 +41,39 @@ describe ActiveTriples::Relation do
   end
 
   describe "#valid_datatype?" do
-    before do
-      allow(subject.parent).to receive(:rdf_subject) { "parent subject" } 
-    end
-
+    subject { described_class.new(double("parent", reflections: []), "value" ) }
+    before { allow(subject.parent).to receive(:rdf_subject) { "parent subject" } }
     context "the value is not a Resource" do
       it "should be true if value is a String" do
         expect(subject.send(:valid_datatype?, "foo")).to be true
       end
-
       it "should be true if value is a Symbol" do
         expect(subject.send(:valid_datatype?, :foo)).to be true
       end
-
       it "should be true if the value is a Numeric" do
         expect(subject.send(:valid_datatype?, 1)).to be true
         expect(subject.send(:valid_datatype?, 0.1)).to be true
       end
-
       it "should be true if the value is a Date" do
         expect(subject.send(:valid_datatype?, Date.today)).to be true
       end
-
       it "should be true if the value is a Time" do
         expect(subject.send(:valid_datatype?, Time.now)).to be true
       end
-
       it "should be true if the value is a boolean" do
         expect(subject.send(:valid_datatype?, false)).to be true
         expect(subject.send(:valid_datatype?, true)).to be true
       end
     end
-
     context "the value is a Resource" do
       after { Object.send(:remove_const, :DummyResource) }
-
       let(:resource) { DummyResource.new }
-
       context "and the resource class does not include RDF::Isomorphic" do
         before { class DummyResource; include ActiveTriples::RDFSource; end }
-
         it "should be false" do
           expect(subject.send(:valid_datatype?, resource)).to be false
         end
       end
-
       context "and the resource class includes RDF:Isomorphic" do
         before do
           class DummyResource
@@ -97,12 +81,10 @@ describe ActiveTriples::Relation do
             include RDF::Isomorphic
           end
         end
-
         it "should be false" do
           expect(subject.send(:valid_datatype?, resource)).to be false
         end
       end
-
       context "and the resource class includes RDF::Isomorphic and aliases :== to :isomorphic_with?" do
         before do
           class DummyResource
@@ -111,7 +93,6 @@ describe ActiveTriples::Relation do
             alias_method :==, :isomorphic_with?
           end
         end
-
         it "should be false" do
           expect(subject.send(:valid_datatype?, resource)).to be false
         end
@@ -119,32 +100,4 @@ describe ActiveTriples::Relation do
     end
   end
 
-  describe '#empty_property' do
-
-    before { resource << RDF::Statement(resource, property, 'value') }
-
-    subject { described_class.new(resource, value_args) }
-    let(:resource) { ActiveTriples::Resource.new }
-    let(:property) { RDF::URI.new('http://example.com/moomin') }
-
-    let(:value_args) do
-      double('value args', 
-             length: 1,
-             first: 'first',
-             last: property)
-    end
-
-    it 'deletes values from property' do
-      expect { subject.empty_property }.to change { subject.result }
-                                            .from(['value']).to([])
-    end
-
-    it 'deletes multiple values from property' do
-      values = [Date.today, 'value2', RDF::Node.new, true]
-      resource.set_value(property, values)
-
-      expect { subject.empty_property }.to change { subject.result }
-                                            .from(values).to([])
-    end
-  end
 end


### PR DESCRIPTION
This reverts "deleting all values when emptying a relation"

I think I merged this hastily - this removes the feature that allows two properties to share the same predicate, which is required by projects like ActiveFedora. Before it's removed entirely, I'd like to see a substitute.