### PR TITLE
Cleanup and unit tests for `RDFSource#get_value`

### DIFF
--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -322,12 +322,25 @@ module ActiveTriples
     # requested. Elements in the array may RdfResource objects or a
     # valid datatype.
     #
-    # Handles two argument patterns. The recommended pattern is:
+    # Handles two argument patterns. The recommended pattern, which accesses
+    # properties directly on this RDFSource, is:
     #    get_values(property)
     #
-    # For backwards compatibility, there is support for explicitly
-    # passing the rdf_subject to be used in th statement:
-    #    get_values(uri, property)
+    # @overload get_values(property) 
+    #   Gets values on the RDFSource for the given property
+    #   @param [String, #to_term] property  the property for the values
+    #
+    # @overload get_values(uri, property)
+    #   For backwards compatibility, explicitly passing the term used as the
+    #   subject {ActiveTriples::Relation#rdf_subject} of the returned relation.
+    #   @param [RDF::Term] uri  the term to use as the subject
+    #   @param [String, #to_term] property  the property for the values
+    #
+    # @return [ActiveTriples::Relation] an array {Relation} containing the 
+    #   values of the property
+    #
+    # @todo should this raise an error when the property argument is not an 
+    #   {RDF::Term} or a registered property key?
     def get_values(*args)
       get_relation(args)
     end
@@ -340,6 +353,9 @@ module ActiveTriples
       get_relation([uri_or_term_property])
     end
 
+    ##
+    # @see #get_values
+    # @todo deprecate and remove? this is an alias to `#get_values`
     def get_relation(args)
       @relation_cache ||= {}
       rel = Relation.new(self, args)

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -132,6 +132,16 @@ module ActiveTriples
       value_arguments.last
     end
 
+    ##
+    # Gives the predicate used by the Relation. Values of this object are 
+    # those that match the pattern `<rdf_subject> <predicate> [value] .`
+    #
+    # @return [RDF::Term] the predicate for this relation
+    def predicate
+      return property if property.is_a?(RDF::Term)
+      property_config[:predicate] unless property_config.nil?
+    end
+
     protected
 
       def node_cache
@@ -166,16 +176,6 @@ module ActiveTriples
         end
         self.node_cache[resource.rdf_subject] = (object ? object : resource)
         resource.persist! if resource.persistence_strategy.is_a? ParentStrategy
-      end
-
-      ##
-      # Gives the predicate used by the Relation. Values of this object are 
-      # those that match the pattern `<rdf_subject> <predicate> [value] .`
-      #
-      # @return [RDF::Term] the predicate for this relation
-      def predicate
-        return property if property.is_a?(RDF::Term)
-        property_config[:predicate] unless property_config.nil?
       end
 
       def valid_datatype?(val)

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -11,13 +11,18 @@ module ActiveTriples
   # Relations, then, express n binary relationships between the parent node and
   # a term.
   #
+  # 
+  #
   # @see RDF::Term
   class Relation
-
+    include Enumerable
+    
     attr_accessor :parent, :value_arguments, :node_cache, :rel_args
     attr_reader :reflections
 
-    delegate *(Array.public_instance_methods - [:send, :__send__, :__id__, :class, :object_id] + [:as_json]), :to => :result
+    # delegate *(Array.public_instance_methods - [:send, :__send__, :__id__, :class, :object_id] + [:as_json]), :to => :result
+    delegate :[], :each, :empty?, :to_a, :to_ary, :<=>, :==, :equal, :===, :last, 
+       :to => :result
 
     def initialize(parent_source, value_arguments)
       self.parent = parent_source
@@ -38,16 +43,16 @@ module ActiveTriples
     end
 
     def result
-      parent.query(:subject => rdf_subject, :predicate => predicate)
-        .each_with_object([]) do |x, collector|
-          converted_object = convert_object(x.object)
-          collector << converted_object unless converted_object.nil?
+      statements = parent.query(:subject => rdf_subject, :predicate => predicate)
+      statements.each_with_object([]) do |x, collector|
+        converted_object = convert_object(x.object)
+        collector << converted_object unless converted_object.nil?
       end
     end
 
     def set(values)
+      values = values.to_a if values.is_a? Relation
       values = [values].compact unless values.kind_of?(Array)
-      values = values.to_a if values.class == Relation
       empty_property
       values.each do |val|
         set_value(val)
@@ -101,8 +106,13 @@ module ActiveTriples
       self.set(values)
     end
 
+    # @todo find a way to simplify this?
     def property_config
-      return type_property if (property == RDF.type || property.to_s == "type") && (!reflections.kind_of?(RDFSource) || !reflections.reflect_on_property(property))
+      return type_property if 
+        (property == RDF.type || property.to_s == "type") && 
+        (!reflections.kind_of?(RDFSource) || 
+         !reflections.reflect_on_property(property))
+      
       reflections.reflect_on_property(property)
     end
 
@@ -113,6 +123,11 @@ module ActiveTriples
     def reset!
     end
 
+    ##
+    # Returns the property for the Relation. This may be a registered property key
+    #
+    # @return the property for this Relation.
+    # @see predicate
     def property
       value_arguments.last
     end
@@ -153,8 +168,14 @@ module ActiveTriples
         resource.persist! if resource.persistence_strategy.is_a? ParentStrategy
       end
 
+      ##
+      # Gives the predicate used by the Relation. Values of this object are 
+      # those that match the pattern `<rdf_subject> <predicate> [value] .`
+      #
+      # @return [RDF::Term] the predicate for this relation
       def predicate
-        property.kind_of?(RDF::URI) ? property : property_config[:predicate]
+        return property if property.is_a?(RDF::Term)
+        property_config[:predicate] unless property_config.nil?
       end
 
       def valid_datatype?(val)
@@ -233,13 +254,15 @@ module ActiveTriples
         klass
       end
 
+      ##
+      # @return [RDF::Term] the subject of the relation
       def rdf_subject
-        raise ArgumentError, "wrong number of arguments (#{value_arguments.length} for 1-2)" if value_arguments.length < 1 || value_arguments.length > 2
-        if value_arguments.length > 1
-          value_arguments.first
-        else
-          parent.rdf_subject
+        if value_arguments.length < 1 || value_arguments.length > 2
+          raise(ArgumentError, 
+                "wrong number of arguments (#{value_arguments.length} for 1-2)")
         end
+
+        value_arguments.length > 1 ? value_arguments.first : parent.rdf_subject
       end
   end
 end

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -146,6 +146,34 @@ describe ActiveTriples::RDFSource do
     it 'sets a value'
   end
 
+  describe '#get_value' do
+    context 'with no matching property' do
+      it 'returns a Relation' do
+        expect(subject.get_values(:not_a_predicate))
+          .to be_a ActiveTriples::Relation
+      end
+
+      it 'is empty' do
+        expect(subject.get_values(:not_a_predicate))
+          .to be_empty
+      end
+    end
+
+    context 'with an empty predicate' do
+      let(:predicate) { RDF::URI('http://example.org/empty') }
+
+      it 'returns a Relation' do
+        expect(subject.get_values(predicate)).to be_a ActiveTriples::Relation
+      end
+
+      it 'is empty' do
+        expect(subject.get_values(predicate)).to be_empty
+      end
+    end
+
+    it 'gets a value'
+  end
+
   describe 'validation' do
     it { is_expected.to be_valid }
 

--- a/spec/active_triples/relation_spec.rb
+++ b/spec/active_triples/relation_spec.rb
@@ -2,6 +2,27 @@ require 'spec_helper'
 require 'rdf/isomorphic'
 
 describe ActiveTriples::Relation do
+  let(:parent_resource) { double("parent resource", reflections: {}) }
+
+  subject { described_class.new(parent_resource, double("value args") ) }
+
+  describe "#predicate" do
+    subject { described_class.new(parent_resource, [predicate] ) }
+
+    context 'when the property is an RDF::Term' do
+      let(:predicate) { RDF::URI('http://example.org/moomin') }
+      
+      it 'returns the specified RDF::Term' do
+        expect(subject.send(:predicate)).to eq predicate
+      end
+    end
+
+    context 'when the property is a symbol' do
+      # unit tests here are hard. There are too many moving parts for something
+      # so simple 
+      it 'returns the reflected property'
+    end
+  end
 
   describe "#rdf_subject" do
     let(:parent_resource) { double("parent resource", reflections: {}) }
@@ -10,30 +31,38 @@ describe ActiveTriples::Relation do
 
     context "when relation has 0 value arguments" do
       before { subject.value_arguments = double(length: 0) }
+
       it "should raise an error" do
         expect { subject.send(:rdf_subject) }.to raise_error
       end
     end
+
     context "when term has 1 value argument" do
       before do
         allow(subject.parent).to receive(:rdf_subject) { "parent subject" }
         subject.value_arguments = double(length: 1)
       end
+
       it "should call `rdf_subject' on the parent" do
         expect(subject.send(:rdf_subject) ).to eq "parent subject"
       end
+
       it " is a private method" do
         expect { subject.rdf_subject }.to raise_error NoMethodError
       end
     end
+
     context "when relation has 2 value arguments" do
       before { subject.value_arguments = double(length: 2, first: "first") }
+
       it "should return the first value argument" do
         expect(subject.send(:rdf_subject) ).to eq "first"
       end
     end
+
     context "when relation has 3 value arguments" do
       before { subject.value_arguments = double(length: 3) }
+
       it "should raise an error" do
         expect { subject.send(:rdf_subject)  }.to raise_error
       end
@@ -65,6 +94,7 @@ describe ActiveTriples::Relation do
         expect(subject.send(:valid_datatype?, true)).to be true
       end
     end
+
     context "the value is a Resource" do
       after { Object.send(:remove_const, :DummyResource) }
       let(:resource) { DummyResource.new }

--- a/spec/active_triples/relation_spec.rb
+++ b/spec/active_triples/relation_spec.rb
@@ -13,7 +13,7 @@ describe ActiveTriples::Relation do
       let(:predicate) { RDF::URI('http://example.org/moomin') }
       
       it 'returns the specified RDF::Term' do
-        expect(subject.send(:predicate)).to eq predicate
+        expect(subject.predicate).to eq predicate
       end
     end
 


### PR DESCRIPTION
To make `#get_value` more consistent, this refactors `ActiveTriples::Relation` to delegate a smaller method footprint to its `#result`. This closes #41, but the fallout should be watched carefully.

I intend this as a first step toward #120.