### PR TITLE
Backports RDFSource#== to 0.7.x

### DIFF
--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -216,6 +216,20 @@ module ActiveTriples
     end
 
     ##
+    # Compares self to other for {RDF::Term} equality.
+    #
+    # Delegates the check to `other#==` passing it the term version of `self`.
+    #
+    # @param other [Object]
+    #
+    # @see RDF::Term#==
+    # @see RDF::Node#==
+    # @see RDF::URI#==
+    def ==(other)
+      other == to_term
+    end
+
+    ##
     # Looks for labels in various default fields, prioritizing
     # configured label fields.
     def rdf_label

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -1,11 +1,44 @@
 require 'spec_helper'
 
 describe ActiveTriples::RDFSource do
-  let(:dummy_source) { Class.new { include ActiveTriples::RDFSource } }
+
+  let(:source_class) { Class.new { include ActiveTriples::RDFSource } }
+  let(:uri) { RDF::URI('http://example.org/moomin') }
 
   subject { source_class.new }
 
+  describe '#==' do
+
+    shared_examples 'Term equality' do
+      it 'equals itself' do
+        expect(subject).to eq subject
+      end
+
+      it 'equals its clone' do
+        expect(subject).to eq source_class.new(subject.rdf_subject)
+      end
+
+      it 'does not equal another term' do
+        expect(subject).not_to eq RDF::Node.new
+      end
+
+      it 'does not equal another term' do
+        expect(subject).not_to eq source_class.new
+      end
+    end
+
+    include_examples 'Term equality'
+
+    context 'with a URI' do
+      include_examples 'Term equality' do
+        subject { source_class.new(uri) }
+      end
+    end
+  end
+
   describe ".apply_schema" do
+    let(:dummy_source) { Class.new { include ActiveTriples::RDFSource } }
+
     before do
       class MyDataModel < ActiveTriples::Schema
         property :test_title, :predicate => RDF::DC.title


### PR DESCRIPTION
In 0.6.x, `#==` was handled through `Graph`, this was removed as we moved toward implementing RDFSource using the appropriate RDF.rb mixins, but not replaced in this version. This caused the equality check to compare individual statements directly.

This backports the 0.8.x approach to 0.7.x. See: https://github.com/ActiveTriples/ActiveTriples/issues/121