### PR TITLE
Removes odd logic surrounding property clearance

### DIFF
--- a/lib/active_triples.rb
+++ b/lib/active_triples.rb
@@ -53,6 +53,9 @@ module ActiveTriples
              'active_triples/persistence_strategies/parent_strategy'
     autoload :RepositoryStrategy,
              'active_triples/persistence_strategies/repository_strategy'
+
+    # error classes
+    autoload :UndefinedPropertyError
   end
   
   ##

--- a/lib/active_triples/list.rb
+++ b/lib/active_triples/list.rb
@@ -162,6 +162,7 @@ module ActiveTriples
       if subject == RDF.nil
         @subject = RDF::Node.new
         @graph = ListResource.new(subject)
+        @graph.list = self
         @graph.type = RDF.List
       end
 

--- a/lib/active_triples/properties.rb
+++ b/lib/active_triples/properties.rb
@@ -2,9 +2,8 @@ require 'active_support/core_ext/hash'
 
 module ActiveTriples
   ##
-  # Implements property configuration common to Rdf::Resource,
-  # RDFDatastream, and others.  It does its work at the class level,
-  # and is meant to be extended.
+  # Implements property configuration in the style of RDFSource. It does its 
+  # work at the class level, and is meant to be extended.
   #
   # Define properties at the class level with:
   #
@@ -16,17 +15,39 @@ module ActiveTriples
     included do
       initialize_generated_modules
     end
-
+    
+    ##
+    # Class methods for classes with `Properties`
     module ClassMethods
       def inherited(child_class) #:nodoc:
         child_class.initialize_generated_modules
         super
       end
 
-      def initialize_generated_modules # :nodoc:
+      ##
+      # If the property methods are not yet present, generates them.
+      #
+      # @return [Module] a module self::GeneratedPropertyMethods which is 
+      #   included in self and defines the property methods
+      #
+      # @note this is an alias to #generated_property_methods. Use it when you 
+      #   intend to initialize, rather than retrieve, the methods for code
+      #   readability
+      # @see #generated_property_methods
+      def initialize_generated_modules
         generated_property_methods
       end
 
+      ##
+      # Gives existing generated property methods. If the property methods are 
+      # not yet present, generates them as a new Module and includes it.
+      #
+      # @return [Module] a module self::GeneratedPropertyMethods which is 
+      #   included in self and defines the property methods
+      #
+      # @note use the alias #initialize_generated_modules for clarity of intent
+      #   where appropriate
+      # @see #initialize_generated_modules
       def generated_property_methods
         @generated_property_methods ||= begin
           mod = const_set(:GeneratedPropertyMethods, Module.new)
@@ -37,15 +58,27 @@ module ActiveTriples
 
       ##
       # Registers properties for Resource-like classes
+      #
       # @param [Symbol]  name of the property (and its accessor methods)
       # @param [Hash]  opts for this property, must include a :predicate
       # @yield [index] index sets solr behaviors for the property
+      #
+      # @return [Hash{String=>ActiveTriples::NodeConfig}] the full current 
+      #   property configuration for the class
       def property(name, opts={}, &block)
         raise ArgumentError, "#{name} is a keyword and not an acceptable property name." if protected_property_name? name
         reflection = PropertyBuilder.build(self, name, opts, &block)
         Reflection.add_reflection self, name, reflection
       end
 
+      ##
+      # Checks potential property names for conflicts with existing class 
+      # instance methods. We avoid setting properties with these names to 
+      # prevent catastrophic method overwriting.
+      #
+      # @param [Symblol] name  A potential property name.
+      # @return [Boolean] true if the given name matches an existing instance 
+      #   method which is not an ActiveTriples property.
       def protected_property_name?(name)
         reject = self.instance_methods.map! { |s| s.to_s.gsub(/=$/, '').to_sym }
         reject -= properties.keys.map { |k| k.to_sym }
@@ -56,9 +89,9 @@ module ActiveTriples
       # Given a property name or a predicate, return the configuration
       # for the matching property.
       #
-      # @param term [#to_sym, RDF::Resource] a property name to predicate
+      # @param [#to_sym, RDF::Resource] term  property name or predicate
       #
-      # @return [ActiveTriples::NodeConfig]
+      # @return [ActiveTriples::NodeConfig] the configuration for the property
       def config_for_term_or_uri(term)
         return properties[term.to_s] unless
           term.is_a?(RDF::Resource) && !term.is_a?(RDFSource)

--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -325,17 +325,58 @@ module ActiveTriples
     end
 
     ##
-    # Adds or updates a property with supplied values.
+    # Adds or updates a property by creating triples for each of the supplied
+    # values.
     #
-    # Handles two argument patterns. The recommended pattern is:
-    #    set_value(property, values)
+    # The `property` argument may be either a symbol representing a registered
+    # property name, or an RDF::Term to use as the predicate.
     #
-    # For backwards compatibility, there is support for explicitly
-    # passing the rdf_subject to be used in the statement:
-    #    set_value(uri, property, values)
+    # @example setting with a property name
+    #   class Thing
+    #     include ActiveTriples::RDFSource
+    #     property :creator, predicate: RDF::DC.creator
+    #   end
+    # 
+    #   t = Thing.new
+    #   t.set_value(:creator, 'Tove Jansson')  # => ['Tove Jansson']
     #
-    # @note This method will delete existing statements with the correct 
+    #
+    # @example setting with a predicate
+    #   t = Thing.new
+    #   t.set_value(RDF::DC.creator, 'Tove Jansson')  # => ['Tove Jansson']
+    #   
+    #
+    # The recommended pattern, which sets properties directly on this 
+    # RDFSource, is: `set_value(property, values)`
+    #
+    # @overload set_value(property, values)
+    #   Updates the values for the property, using this RDFSource as the subject
+    #
+    #   @param [RDF::Term, #to_sym] property  a symbol with the property name
+    #     or an RDF::Term to use as a predicate.
+    #   @param [Array<RDF::Resource>, RDF::Resource] values  an array of values
+    #     or a single value. If not an {RDF::Resource}, the values will be 
+    #     coerced to an {RDF::Literal} or {RDF::Node} by {RDF::Statement}
+    #
+    # @overload set_value(subject, property, values)
+    #   Updates the values for the property, using the given term as the subject
+    # 
+    #   @param [RDF::Term] subject  the term representing the 
+    #   @param [RDF::Term, #to_sym] property  a symbol with the property name
+    #     or an RDF::Term to use as a predicate.
+    #   @param [Array<RDF::Resource>, RDF::Resource] values  an array of values
+    #     or a single value. If not an {RDF::Resource}, the values will be 
+    #     coerced to an {RDF::Literal} or {RDF::Node} by {RDF::Statement}
+    #
+    # @return [ActiveTriples::Relation] an array {Relation} containing the
+    #   values of the property
+    #
+    # @note This method will delete existing statements with the given
     #   subject and predicate from the graph
+    #
+    # @see http://www.rubydoc.info/github/ruby-rdf/rdf/RDF/Statement For 
+    #   documentation on {RDF::Statement} and the handling of 
+    #   non-{RDF::Resource} values.
     def set_value(*args)
       # Add support for legacy 3-parameter syntax
       if args.length > 3 || args.length < 2

--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -413,6 +413,9 @@ module ActiveTriples
     # @return [ActiveTriples::Relation] an array {Relation} containing the
     #   values of the property
     #
+    # @raise [ActiveTriples::Relation::ValueError] when the given value can't be
+    #   coerced into an acceptable `RDF::Term`.
+    #
     # @note This method will delete existing statements with the given
     #   subject and predicate from the graph
     #

--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -124,41 +124,12 @@ module ActiveTriples
       other == to_term
     end
 
-    ##
-    # Delegate parent to the persistence strategy if possible
-    #
-    # @todo establish a better pattern for this. `#parent` has been a public method
-    #   in the past, but it's probably time to deprecate it.
-    def parent
-      persistence_strategy.respond_to?(:parent) ? persistence_strategy.parent : nil
-    end
-
-    ##
-    # @todo deprecate/remove
-    # @see #parent
-    def parent=(parent)
-      persistence_strategy.respond_to?(:parent=) ? (persistence_strategy.parent = parent) : nil
-    end
-
     def attributes
       attrs = {}
       attrs['id'] = id if id
       fields.map { |f| attrs[f.to_s] = get_values(f) }
       unregistered_predicates.map { |uri| attrs[uri.to_s] = get_values(uri) }
       attrs
-    end
-
-    def serializable_hash(options = nil)
-      attrs = (fields.map { |f| f.to_s }) << 'id'
-      hash = super(:only => attrs)
-      unregistered_predicates.map { |uri| hash[uri.to_s] = get_values(uri) }
-      hash
-    end
-
-    ##
-    # @return [Class] gives `self#class`
-    def reflections
-      self.class
     end
 
     def attributes=(values)
@@ -175,6 +146,13 @@ module ActiveTriples
           raise ArgumentError, "No association found for name `#{key}'. Has it been defined yet?"
         end
       end
+    end
+
+    def serializable_hash(options = nil)
+      attrs = (fields.map { |f| f.to_s }) << 'id'
+      hash = super(:only => attrs)
+      unregistered_predicates.map { |uri| hash[uri.to_s] = get_values(uri) }
+      hash
     end
 
     ##
@@ -196,7 +174,23 @@ module ActiveTriples
     end
 
     ##
-    # Gives the representation of this
+    # Delegate parent to the persistence strategy if possible
+    #
+    # @todo establish a better pattern for this. `#parent` has been a public method
+    #   in the past, but it's probably time to deprecate it.
+    def parent
+      persistence_strategy.respond_to?(:parent) ? persistence_strategy.parent : nil
+    end
+
+    ##
+    # @todo deprecate/remove
+    # @see #parent
+    def parent=(parent)
+      persistence_strategy.respond_to?(:parent=) ? (persistence_strategy.parent = parent) : nil
+    end
+
+    ##
+    # Gives the representation of this RDFSource as an RDF::Term
     #
     # @return [RDF::URI, RDF::Node] the URI that identifies this `RDFSource`;
     #   or a bnode identifier
@@ -267,7 +261,7 @@ module ActiveTriples
     end
 
     def type
-      self.get_values(:type).to_a
+      self.get_values(:type)
     end
 
     def type=(type)
@@ -286,6 +280,14 @@ module ActiveTriples
         return values unless values.empty?
       end
       node? ? [] : [rdf_subject.to_s]
+    end
+
+    def default_labels
+      [RDF::SKOS.prefLabel,
+       RDF::DC.title,
+       RDF::RDFS.label,
+       RDF::SKOS.altLabel,
+       RDF::SKOS.hiddenLabel]
     end
 
     ##
@@ -387,14 +389,6 @@ module ActiveTriples
     end
 
     ##
-    # Adds or updates a property with supplied values.
-    #
-    # @note This method will delete existing statements with the correct subject and predicate from the graph
-    def []=(uri_or_term_property, value)
-      self[uri_or_term_property].set(value)
-    end
-
-    ##
     # Returns an array of values belonging to the property
     # requested. Elements in the array may RdfResource objects or a
     # valid datatype.
@@ -423,11 +417,25 @@ module ActiveTriples
     end
 
     ##
-    # Returns an array of values belonging to the property
-    # requested. Elements in the array may RdfResource objects or a
-    # valid datatype.
-    def [](uri_or_term_property)
-      get_relation([uri_or_term_property])
+    # Returns an array of values belonging to the property requested. Elements
+    # in the array may RdfResource objects or a valid datatype.
+    # 
+    # @param [RDF::Term, :to_s] term_or_property
+    def [](term_or_property)
+      get_relation([term_or_property])
+    end
+
+    ##
+    # Adds or updates a property with supplied values.
+    #
+    # @param [RDF::Term, :to_s] term_or_property
+    # @param [Array<RDF::Resource>, RDF::Resource] values  an array of values
+    #   or a single value to set the property to.   
+    #
+    # @note This method will delete existing statements with the correct 
+    #   subject and predicate from the graph
+    def []=(term_or_property, value)
+      self[term_or_property].set(value)
     end
 
     ##
@@ -495,6 +503,15 @@ module ActiveTriples
 
     private
 
+      ##
+      # This gives the {RDF::Graph} which represents the current state of this
+      # resource.
+      #  
+      # @return [RDF::Graph] the underlying graph representation of the
+      #   `RDFSource`.
+      #
+      # @see http://www.w3.org/TR/2014/REC-rdf11-concepts-20140225/#change-over-time
+      #   RDF Concepts and Abstract Syntax comment on "RDF source"
       def graph
         @graph
       end

--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -167,7 +167,7 @@ module ActiveTriples
       id = values.delete(:id)
       set_subject!(id) if id && node?
       values.each do |key, value|
-        if reflections.reflect_on_property(key)
+        if reflections.has_property?(key)
           set_value(rdf_subject, key, value)
         elsif nested_attributes_options.keys.map { |k| "#{k}_attributes" }.include?(key)
           send("#{key}=".to_sym, value)

--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -271,6 +271,8 @@ module ActiveTriples
     ##
     # Looks for labels in various default fields, prioritizing
     # configured label fields.
+    #
+    # @see #default_labels
     def rdf_label
       labels = Array.wrap(self.class.rdf_label)
       labels += default_labels
@@ -281,6 +283,8 @@ module ActiveTriples
       node? ? [] : [rdf_subject.to_s]
     end
 
+    ##
+    # @return [Array<RDF::URI>] a group of properties to use for default labels.
     def default_labels
       [RDF::SKOS.prefLabel,
        RDF::DC.title,

--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -232,7 +232,7 @@ module ActiveTriples
     ##
     # @return [RDF::URI] the uri
     def to_uri
-      uri? ? rdf_subject : NullURI.new
+      rdf_subject if uri?
     end
 
     ##
@@ -334,7 +334,8 @@ module ActiveTriples
     # passing the rdf_subject to be used in the statement:
     #    set_value(uri, property, values)
     #
-    # @note This method will delete existing statements with the correct subject and predicate from the graph
+    # @note This method will delete existing statements with the correct 
+    #   subject and predicate from the graph
     def set_value(*args)
       # Add support for legacy 3-parameter syntax
       if args.length > 3 || args.length < 2

--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -46,7 +46,6 @@ module ActiveTriples
     include NestedAttributes
     include Persistable
     include Properties
-    include Reflection
     include RDF::Value
     include RDF::Queryable
     include ActiveModel::Validations
@@ -176,8 +175,8 @@ module ActiveTriples
     ##
     # Delegate parent to the persistence strategy if possible
     #
-    # @todo establish a better pattern for this. `#parent` has been a public method
-    #   in the past, but it's probably time to deprecate it.
+    # @todo establish a better pattern for this. `#parent` has been a public 
+    #   method in the past, but it's probably time to deprecate it.
     def parent
       persistence_strategy.respond_to?(:parent) ? persistence_strategy.parent : nil
     end
@@ -517,6 +516,7 @@ module ActiveTriples
       end
 
       ##
+
       # Lists fields registered as properties on the object.
       #
       # @return [Array<Symbol>] the list of registered properties.

--- a/lib/active_triples/reflection.rb
+++ b/lib/active_triples/reflection.rb
@@ -10,7 +10,8 @@ module ActiveTriples
     end
 
     def self.add_reflection(model, name, reflection)
-      model._active_triples_config = model._active_triples_config.merge(name.to_s => reflection)
+      model._active_triples_config = 
+        model._active_triples_config.merge(name.to_s => reflection)
     end
 
     module ClassMethods
@@ -34,6 +35,11 @@ module ActiveTriples
         _active_triples_config
       end
 
+      ##
+      # @param [Hash{String=>ActiveTriples::NodeConfig}] a complete config hash
+      #   to set the properties to.
+      # @return [Hash{String=>ActiveTriples::NodeConfig}] a hash of property 
+      #   names and their configurations
       def properties=(val)
         self._active_triples_config = val
       end

--- a/lib/active_triples/reflection.rb
+++ b/lib/active_triples/reflection.rb
@@ -14,16 +14,36 @@ module ActiveTriples
     end
 
     module ClassMethods
-      def reflect_on_property(term)
-        _active_triples_config[term.to_s]
+      ##
+      # @param [#to_s] property
+      #
+      # @return [ActiveTriples::NodeConfig] the configuration for the property
+      #
+      # @raise [ActiveTriples::UndefinedPropertyError] when the property does 
+      #   not exist
+      def reflect_on_property(property)
+        _active_triples_config.fetch(property.to_s) do
+          raise ActiveTriples::UndefinedPropertyError.new(property.to_s, self)
+        end
       end
 
+      ##
+      # @return [Hash{String=>ActiveTriples::NodeConfig}] a hash of property 
+      #   names and their configurations
       def properties
         _active_triples_config
       end
 
       def properties=(val)
         self._active_triples_config = val
+      end
+
+      ##
+      # @param [#to_s] property
+      #
+      # @return [Boolean] true if the property exsits; false otherwise
+      def has_property?(property)
+        _active_triples_config.keys.include? property.to_s
       end
     end
   end

--- a/lib/active_triples/reflection.rb
+++ b/lib/active_triples/reflection.rb
@@ -9,6 +9,18 @@ module ActiveTriples
       self._active_triples_config = {}
     end
 
+    ##
+    # Gives access to a `Reflection` of the properties configured on this class
+    #
+    # @example
+    #   my_source.reflections.has_property?(:title)
+    #   my_source.reflections.reflect_on_property(:title)
+    # @return [Class] gives `self#class`
+    #
+    def reflections
+      self.class
+    end
+
     def self.add_reflection(model, name, reflection)
       model._active_triples_config = 
         model._active_triples_config.merge(name.to_s => reflection)

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -164,9 +164,9 @@ module ActiveTriples
         valid_datatype?(val) ? RDF::Literal(val) : val
       end
 
-      def add_child_node(resource,object=nil)
+      def add_child_node(resource, object = nil)
         parent.insert [rdf_subject, predicate, resource.rdf_subject]
-        unless resource.frozen?
+        unless resource.frozen? || resource == parent
           resource.set_persistence_strategy(ParentStrategy)
           resource.parent = parent
         end

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -125,8 +125,54 @@ module ActiveTriples
       self
     end
 
+    ##
+    # Builds a node with the given attributes, adding it to the relation.
+    #
+    # @param attributes [Hash] a hash of attribute names and values for the 
+    #   built node.
+    #
+    # @example building an empty generic node
+    #   resource = ActiveTriples::Resource.new
+    #   resource.resource.get_values(RDF::Vocab::DC.relation).build
+    #   # => #<ActiveTriples::Resource:0x2b0(#<ActiveTriples::Resource:0x005>)>)
+    #
+    #   resource.dump :ttl
+    #   # => "\n [ <http://purl.org/dc/terms/relation> []] .\n"
+    #
+    # Nodes are built using the configured `class_name` for the relation. 
+    # Attributes passed in the Hash argument are set on the new node through
+    # `RDFSource#attributes=`. If the attribute keys are not valid properties 
+    # on the built node, we raise an error.
+    #
+    # @example building a node with attributes
+    #   class WithRelation
+    #     include ActiveTriples::RDFSource
+    #     property :relation, predicate:  RDF::Vocab::DC.relation, 
+    #       class_name: 'WithTitle'
+    #   end
+    #
+    #   class WithTitle
+    #     include ActiveTriples::RDFSource
+    #     property :title, predicate: RDF::Vocab::DC.title
+    #   end
+    #
+    #   resource = WithRelation.new
+    #   attributes = { id: 'http://ex.org/moomin', title: 'moomin' }
+    #
+    #   resource.get_values(:relation).build(attributes)
+    #   # => #<ActiveTriples::Resource:0x2b0(#<ActiveTriples::Resource:0x005>)>)
+    #
+    #   resource.dump :ttl
+    #   # => "\n<http://ex.org/moomin> <http://purl.org/dc/terms/title> \"moomin\" .\n\n [ <http://purl.org/dc/terms/relation> <http://ex.org/moomin>] .\n"
+    #
+    # @todo: clarify class behavior; it is actually tied to type, in some cases.
+    #
+    # @see RDFSource#attributes=
+    # @see http://guides.rubyonrails.org/active_model_basics.html for some 
+    #   context on ActiveModel attributes.
     def build(attributes={})
       new_subject = attributes.fetch('id') { RDF::Node.new }
+
       make_node(new_subject).tap do |node|
         node.attributes = attributes.except('id')
         if parent.kind_of? List::ListResource

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -233,10 +233,15 @@ module ActiveTriples
 
       def add_child_node(resource, object = nil)
         parent.insert [rdf_subject, predicate, resource.rdf_subject]
-        unless resource.frozen? || resource == parent
+
+        unless resource.frozen? || 
+               resource == parent || 
+               (parent.persistence_strategy.is_a?(ParentStrategy) && 
+                resource == parent.persistence_strategy.final_parent)
           resource.set_persistence_strategy(ParentStrategy)
-          resource.parent = parent
+          resource.parent = parent 
         end
+
         self.node_cache[resource.rdf_subject] = (object ? object : resource)
         resource.persist! if resource.persistence_strategy.is_a? ParentStrategy
       end

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -185,6 +185,10 @@ module ActiveTriples
       end
     end
 
+    ##
+    # @return [Object] the first result, if present; else a newly built node
+    #
+    # @see #build
     def first_or_create(attributes={})
       result.first || build(attributes)
     end

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -53,18 +53,16 @@ module ActiveTriples
     def set(values)
       values = values.to_a if values.is_a? Relation
       values = [values].compact unless values.kind_of?(Array)
+
       empty_property
-      values.each do |val|
-        set_value(val)
-      end
+      values.each { |val| set_value(val) }
+
       parent.persist! if parent.persistence_strategy.is_a? ParentStrategy
     end
 
     def empty_property
       parent.query([rdf_subject, predicate, nil]).each_statement do |statement|
-        if !uri_class(statement.object) || uri_class(statement.object) == class_for_property
-          parent.delete(statement)
-        end
+        parent.delete(statement)
       end
     end
 

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -58,6 +58,7 @@ module ActiveTriples
       values.each { |val| set_value(val) }
 
       parent.persist! if parent.persistence_strategy.is_a? ParentStrategy
+      self
     end
 
     def empty_property

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -8,10 +8,14 @@ module ActiveTriples
   #
   #   <{#parent}> <{#predicate}> [term] .
   #
-  # Relations, then, express n binary relationships between the parent node and
-  # a term.
-  #
+  # Relations express a set of binary relationships (on a predicate) between 
+  # the parent node and a term. 
   # 
+  # When the term is a URI or Blank Node, it is represented in the results
+  # {Array} as an {RDFSource} with a graph selected as a subgraph of the 
+  # parent's. The triples in this subgraph are: (a) those whose subject is the
+  # term; (b) ...
+  #
   #
   # @see RDF::Term
   class Relation
@@ -23,18 +27,17 @@ module ActiveTriples
     delegate :<=>, :==, :===, :[], :each, :empty?, :equal, :inspect, :last, 
        :to_a, :to_ary, :to => :result
 
+    ##
+    # @param [ActiveTriples::RDFSource] parent_source
+    # @param [Array<Symbol, Hash>] value_arguments  if a Hash is passed as the 
+    #   final element, it is removed and set to `@rel_args`.
     def initialize(parent_source, value_arguments)
       self.parent = parent_source
       @reflections = parent_source.reflections
       self.rel_args ||= {}
+      self.rel_args = value_arguments.pop if value_arguments.is_a?(Array) && 
+                                             value_arguments.last.is_a?(Hash)
       self.value_arguments = value_arguments
-    end
-
-    def value_arguments=(value_args)
-      if value_args.kind_of?(Array) && value_args.last.kind_of?(Hash)
-        self.rel_args = value_args.pop
-      end
-      @value_arguments = value_args
     end
 
     def clear

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -41,11 +41,12 @@ module ActiveTriples
     end
 
     ##
+    # Empties the `Relation`, deleting any associated triples from `parent`.
+    #
     # @return [Relation] self; a now empty relation
     def clear
-      parent.query([rdf_subject, predicate, nil]).each_statement do |statement|
-        parent.delete(statement)
-      end
+      parent.delete([rdf_subject, predicate, nil])
+
       self
     end
 

--- a/lib/active_triples/undefined_property_error.rb
+++ b/lib/active_triples/undefined_property_error.rb
@@ -1,0 +1,26 @@
+module ActiveTriples
+  ##
+  # An error class to be raised when attempting to reflect on an undefined 
+  # property.
+  #
+  # @example
+  #   begin 
+  #     my_source.set_value(:fake_property, 'blah')
+  #   rescue ActiveTriples::UndefinedPropertyError => e
+  #     e.property => 'fake_property'
+  #     e.klass => 'MySourceClass'
+  #   end
+  #   
+  class UndefinedPropertyError < ArgumentError
+    attr_reader :property, :klass
+
+    def initialize(property, klass)
+      @property = property
+      @klass = klass
+    end
+
+    def message
+      "The property `#{@property}` is not defined on class '#{@klass}'"
+    end
+  end
+end

--- a/spec/active_triples/list_spec.rb
+++ b/spec/active_triples/list_spec.rb
@@ -31,10 +31,6 @@ describe ActiveTriples::List do
       expect(subject.subject).not_to eq RDF.nil
     end
 
-    it 'has a non-nil subject' do
-      expect(subject.subject).not_to eq RDF.nil
-    end
-
     it 'has type of rdf:List' do
       expect(subject.type.first).to eq RDF.List
     end

--- a/spec/active_triples/properties_spec.rb
+++ b/spec/active_triples/properties_spec.rb
@@ -12,46 +12,50 @@ describe ActiveTriples::Properties do
   end
 
   describe '#property' do
-    it 'should set a property as a NodeConfig' do
+    it 'sets a property as a NodeConfig' do
       DummyProperties.property :title, :predicate => RDF::Vocab::DC.title
       expect(DummyProperties.reflect_on_property(:title)).to be_kind_of ActiveTriples::NodeConfig
     end
 
-    it 'should set the correct property' do
+    it 'sets the correct property' do
       DummyProperties.property :title, :predicate => RDF::Vocab::DC.title
       expect(DummyProperties.reflect_on_property(:title).predicate).to eql RDF::Vocab::DC.title
     end
 
-    it 'should set the correct property from string' do
+    it 'sets the correct property from string' do
       DummyProperties.property :title, :predicate => RDF::Vocab::DC.title.to_s
       expect(DummyProperties.reflect_on_property(:title).predicate).to eql RDF::Vocab::DC.title
     end
 
-    it 'should set index behaviors' do
+    it 'sets index behaviors' do
       DummyProperties.property :title, :predicate => RDF::Vocab::DC.title do |index|
         index.as :facetable, :searchable
       end
-      expect(DummyProperties.reflect_on_property(:title)[:behaviors]).to eq [:facetable, :searchable]
+      expect(DummyProperties.reflect_on_property(:title)[:behaviors])
+        .to eq [:facetable, :searchable]
     end
 
-    it 'should set class name' do
+    it 'sets class name' do
       DummyProperties.property :title, :predicate => RDF::Vocab::DC.title, :class_name => RDF::Literal
       expect(DummyProperties.reflect_on_property(:title)[:class_name]).to eq RDF::Literal
     end
 
-    it "should constantize string class names" do
+    it 'constantizes string class names' do
       DummyProperties.property :title, :predicate => RDF::Vocab::DC.title, :class_name => "RDF::Literal"
       expect(DummyProperties.reflect_on_property(:title)[:class_name]).to eq RDF::Literal
     end
 
-    it "should keep strings which it can't constantize as strings" do
-      DummyProperties.property :title, :predicate => RDF::Vocab::DC.title, :class_name => "FakeClassName"
+    it "keeps strings which it can't constantize as strings" do
+      DummyProperties.property :title, 
+                               :predicate => RDF::Vocab::DC.title, 
+                               :class_name => "FakeClassName"
       expect(DummyProperties.reflect_on_property(:title)[:class_name]).to eq "FakeClassName"
     end
 
     it 'raises error when defining properties that are already methods' do
       DummyProperties.send :define_method, :type, lambda { }
-      expect { DummyProperties.property :type, :predicate => RDF::Vocab::DC.type }.to raise_error ArgumentError
+      expect { DummyProperties.property :type, predicate: RDF::Vocab::DC.type }
+        .to raise_error ArgumentError
     end
 
     it 'raises error when defining properties with no predicate' do
@@ -68,9 +72,10 @@ describe ActiveTriples::Properties do
     end
 
     it 'allows resetting of properties' do
-      DummyProperties.property :title, :predicate => RDF::Vocab::DC.alternative
-      DummyProperties.property :title, :predicate => RDF::Vocab::DC.title
-      expect(DummyProperties.reflect_on_property(:title).predicate).to eq RDF::Vocab::DC.title
+      DummyProperties.property :title, predicate: RDF::Vocab::DC.alternative
+      DummyProperties.property :title, predicate: RDF::Vocab::DC.title
+      expect(DummyProperties.reflect_on_property(:title).predicate)
+        .to eq RDF::Vocab::DC.title
     end
   end
 
@@ -80,15 +85,18 @@ describe ActiveTriples::Properties do
     end
 
     it 'finds property configuration by term symbol' do
-      expect(DummyProperties.config_for_term_or_uri(:title)).to eq DummyProperties.properties['title']
+      expect(DummyProperties.config_for_term_or_uri(:title))
+        .to eq DummyProperties.properties['title']
     end
 
     it 'finds property configuration by term string' do
-      expect(DummyProperties.config_for_term_or_uri('title')).to eq DummyProperties.properties['title']
+      expect(DummyProperties.config_for_term_or_uri('title'))
+        .to eq DummyProperties.properties['title']
     end
 
     it 'finds property configuration by term URI' do
-      expect(DummyProperties.config_for_term_or_uri(RDF::Vocab::DC.title)).to eq DummyProperties.properties['title']
+      expect(DummyProperties.config_for_term_or_uri(RDF::Vocab::DC.title))
+        .to eq DummyProperties.properties['title']
     end
   end
 
@@ -99,7 +107,7 @@ describe ActiveTriples::Properties do
     end
 
     it 'lists its terms' do
-      expect(DummyProperties.fields).to eq [:title, :name]
+      expect(DummyProperties.fields).to contain_exactly(:title, :name)
     end
   end
 
@@ -116,8 +124,23 @@ describe ActiveTriples::Properties do
     end
 
     it 'should carry properties from superclass' do
-      expect(DummySubClass.reflect_on_property(:title)).to be_kind_of ActiveTriples::NodeConfig
-      expect(DummySubClass.reflect_on_property(:source)).to be_kind_of ActiveTriples::NodeConfig
+      expect(DummySubClass.reflect_on_property(:title))
+        .to be_kind_of ActiveTriples::NodeConfig
+      expect(DummySubClass.reflect_on_property(:source))
+        .to be_kind_of ActiveTriples::NodeConfig
+    end
+  end
+
+  describe '#generated_property_methods' do
+    it 'returns a GeneratedPropertyMethods module' do 
+      expect(DummyProperties.generated_property_methods)
+        .to eq DummyProperties::GeneratedPropertyMethods
+    end
+
+    it 'has setter and getter instance methods for set properties' do 
+      DummyProperties.property :title, :predicate => RDF::Vocab::DC.title
+      expect(DummyProperties.generated_property_methods.instance_methods)
+        .to contain_exactly(:title, :title=)
     end
   end
 end

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -210,7 +210,7 @@ describe ActiveTriples::RDFSource do
         .to raise_error ArgumentError
     end
 
-    shared_examples 'value setting' do |value|
+    shared_examples 'value setting' do
       let(:predicate) { RDF::DC.creator } 
       let(:statement) { RDF::Statement(subject, predicate, value) } 
 
@@ -231,19 +231,39 @@ describe ActiveTriples::RDFSource do
     end
     
     context 'with string literal' do
-      include_examples 'value setting', 'blah'
+      include_examples 'value setting' do
+        let(:value) { 'blah' }
+      end
     end
 
     context 'with typed literal' do
-      include_examples 'value setting', Date.today
+      include_examples 'value setting' do
+        let(:value) { Date.today }
+      end
     end
 
     context 'with RDF Term' do
-      include_examples 'value setting', RDF::Node.new
+      include_examples 'value setting' do
+        let(:value) { RDF::Node.new }
+      end
     end
 
-    context 'with URI' do
-      include_examples 'value setting', RDF::URI('http://example.org/snork')
+    context 'with RDFSource URI' do
+      include_examples 'value setting' do
+        let(:value) { source_class.new }
+      end
+    end
+
+    context 'with RDFSource node' do
+      include_examples 'value setting' do
+        let(:value) { source_class.new(uri) }
+      end
+    end
+
+    context 'with self' do
+      include_examples 'value setting' do
+        let(:value) { subject }
+      end
     end
   end
 

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -210,7 +210,41 @@ describe ActiveTriples::RDFSource do
         .to raise_error ArgumentError
     end
 
-    it 'sets a value'
+    shared_examples 'value setting' do |value|
+      let(:predicate) { RDF::DC.creator } 
+      let(:statement) { RDF::Statement(subject, predicate, value) } 
+
+      it 'sets a value' do
+        expect { subject.set_value(predicate, value) }
+          .to change { subject.statements }
+               .to(a_collection_containing_exactly(statement))
+      end
+
+      it 'overwrites existing values' do
+        old_vals = ['old value', RDF::Node.new, RDF::DC.type, RDF::URI('----')]
+        subject.set_value(predicate, old_vals)
+
+        expect { subject.set_value(predicate, value) }
+          .to change { subject.statements }
+               .to(a_collection_containing_exactly(statement))
+      end
+    end
+    
+    context 'with string literal' do
+      include_examples 'value setting', 'blah'
+    end
+
+    context 'with typed literal' do
+      include_examples 'value setting', Date.today
+    end
+
+    context 'with RDF Term' do
+      include_examples 'value setting', RDF::Node.new
+    end
+
+    context 'with URI' do
+      include_examples 'value setting', RDF::URI('http://example.org/snork')
+    end
   end
 
   describe '#get_value' do

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -224,6 +224,20 @@ describe ActiveTriples::RDFSource do
       values.map { |value| RDF::Statement(subject, predicate, value) }
     end
 
+    context 'with no matching property' do
+      it 'is empty' do
+        expect(subject.get_values(:not_a_predicate))
+          .to be_a_relation_containing()
+      end
+    end
+
+    context 'with an empty predicate' do
+      it 'is empty' do
+        expect(subject.get_values(RDF::URI('http://example.org/empty')))
+          .to be_a_relation_containing()
+      end
+    end
+
     it 'gets values for a property name' do
       expect(subject.get_values(property_name))
         .to be_a_relation_containing(*values)
@@ -250,10 +264,23 @@ describe ActiveTriples::RDFSource do
         .to raise_error ArgumentError
     end
 
-    it 'raises an error when given an unregistered property name' do
-      expect { subject.set_value(:not_a_property, 'moomin') }.to raise_error
+    context 'when given an unregistered property name' do
+      it 'raises an error' do
+        expect { subject.set_value(:not_a_property, '') }.to raise_error do |err|
+          expect(err).to be_a ActiveTriples::UndefinedPropertyError
+          expect(err.klass).to eq subject.class
+          expect(err.property).to eq :not_a_property
+        end
+      end
+      
+      it 'is a no-op' do
+        subject << RDF::Statement(subject, RDF::DC.title, 'Moomin')
+        # this is a bit naive
+        expect { subject.set_value(:not_a_property, '') rescue nil }
+          .not_to change { subject.triples.count }
+      end
     end
-
+    
     shared_examples 'setting values' do
       after do
         Object.send(:remove_const, 'SourceWithCreator') if 
@@ -359,34 +386,6 @@ describe ActiveTriples::RDFSource do
         end
       end
     end
-  end
-
-  describe '#get_value' do
-    context 'with no matching property' do
-      it 'returns a Relation' do
-        expect(subject.get_values(:not_a_predicate))
-          .to be_a ActiveTriples::Relation
-      end
-
-      it 'is empty' do
-        expect(subject.get_values(:not_a_predicate))
-          .to be_empty
-      end
-    end
-
-    context 'with an empty predicate' do
-      let(:predicate) { RDF::URI('http://example.org/empty') }
-
-      it 'returns a Relation' do
-        expect(subject.get_values(predicate)).to be_a ActiveTriples::Relation
-      end
-
-      it 'is empty' do
-        expect(subject.get_values(predicate)).to be_empty
-      end
-    end
-
-    it 'gets a value'
   end
 
   describe 'validation' do

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -152,7 +152,7 @@ describe ActiveTriples::RDFSource do
     end
     
     it 'has unregistered properties' do
-      predicate = RDF::Vocab::OWL.sameAs
+      predicate = RDF::OWL.sameAs
       subject << [subject, predicate, 'moomin']
       expect(subject.attributes[predicate.to_s]).to contain_exactly 'moomin'
     end
@@ -463,11 +463,11 @@ describe ActiveTriples::RDFSource do
         document.set_value(RDF::Vocab::DC.creator, person) 
         person.set_value(RDF::Vocab::FOAF.knows, subject) 
         subject.set_value(RDF::Vocab::FOAF.publications, document) 
-        subject.set_value(RDF::Vocab::OWL.sameAs, subject)         
+        subject.set_value(RDF::OWL.sameAs, subject)         
 
         expect(subject.get_values(RDF::Vocab::FOAF.publications))
           .to contain_exactly(document)
-        expect(subject.get_values(RDF::Vocab::OWL.sameAs))
+        expect(subject.get_values(RDF::OWL.sameAs))
           .to contain_exactly(subject)
         expect(document.get_values(RDF::Vocab::DC.creator))
           .to contain_exactly(person)

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -354,6 +354,11 @@ describe ActiveTriples::RDFSource do
         Array.wrap(value).map { |val| RDF::Statement(subject, predicate, val) }
       end
 
+      it 'raises a ValueError when setting a nonsense value' do
+        expect { subject.set_value(predicate, Object.new) }
+          .to raise_error ActiveTriples::Relation::ValueError
+      end
+
       it 'sets a value' do
         expect { subject.set_value(predicate, value) }
           .to change { subject.statements }

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -204,6 +204,28 @@ describe ActiveTriples::RDFSource do
     end
   end
 
+  describe '#rdf_label' do
+    let(:label_prop) { RDF::Vocab::SKOS.prefLabel }
+
+    it 'returns an array of label values' do
+      expect(subject.rdf_label).to be_kind_of Array
+    end
+
+    it 'returns the default label values' do
+      subject << [subject.rdf_subject, label_prop, 'Comet in Moominland']
+      expect(subject.rdf_label).to contain_exactly('Comet in Moominland')
+    end
+
+    it 'prioritizes configured label values' do
+      custom_label = RDF::URI('http://example.org/custom_label')
+      subject.class.configure rdf_label: custom_label
+      subject << [subject.rdf_subject, custom_label, RDF::Literal('New Label')]
+      subject << [subject.rdf_subject, label_prop, 'Comet in Moominland']
+
+      expect(subject.rdf_label).to contain_exactly('New Label')
+    end
+  end
+
   describe '#get_values' do
     before { statements.each { |statement| subject << statement } }
 

--- a/spec/active_triples/reflection_spec.rb
+++ b/spec/active_triples/reflection_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe ActiveTriples::Reflection do
+  subject { klass.new }
+
+  let(:klass) { Class.new { include ActiveTriples::Reflection } }
+
+  let(:config_hash) do
+    { 'moomin' => double('moomin config'),
+      'snorkmaiden' => double('snorkmaiden config') }
+  end
+
+  describe '.properties=' do
+    it 'sets properties' do
+      expect { klass.properties = config_hash }
+        .to change { klass._active_triples_config }.to config_hash
+    end
+  end
+  
+  describe '.properties' do
+    it 'gets the set properties' do
+      klass.properties = config_hash
+
+      expect(klass.properties).to eq config_hash
+    end
+  end
+
+  describe '.has_property?' do
+    before { klass.properties = config_hash }
+
+    it 'returns true for properties it has' do
+      klass._active_triples_config.each do |property, _| 
+        expect(klass).to have_property property
+      end
+    end
+
+    it 'coerces to a string' do
+      klass._active_triples_config.each do |property, _| 
+        expect(klass).to have_property property.to_sym
+      end
+    end
+
+    it 'returns false for unregistered properties' do
+      expect(klass).not_to have_property 'moominmama'
+    end
+  end
+
+  describe '.reflect_on_property' do
+    before { klass.properties = config_hash }
+
+    it 'gets the config for the requested property' do
+      klass._active_triples_config.each do |property, config| 
+        expect(klass.reflect_on_property(property)).to eq config
+      end
+    end
+
+    it 'coerces to a string' do
+      klass._active_triples_config.each do |property, config| 
+        expect(klass.reflect_on_property(property.to_sym)).to eq config
+      end
+    end
+
+    it 'raises an error on unregistered properties' do
+      expect { klass.reflect_on_property(:fake) }.to raise_error do |err|
+        expect(err).to be_a ActiveTriples::UndefinedPropertyError
+        expect(err.klass).to eq klass
+        expect(err.property).to eq :fake.to_s
+      end
+    end
+  end
+end

--- a/spec/active_triples/reflection_spec.rb
+++ b/spec/active_triples/reflection_spec.rb
@@ -10,6 +10,12 @@ describe ActiveTriples::Reflection do
       'snorkmaiden' => double('snorkmaiden config') }
   end
 
+  describe '#reflections' do
+    it 'gives reflections for the instance' do
+      expect(subject.reflections).to eq klass
+    end
+  end
+
   describe '.properties=' do
     it 'sets properties' do
       expect { klass.properties = config_hash }

--- a/spec/active_triples/relation_spec.rb
+++ b/spec/active_triples/relation_spec.rb
@@ -3,24 +3,166 @@ require 'rdf/isomorphic'
 
 describe ActiveTriples::Relation do
   let(:parent_resource) { double("parent resource", reflections: {}) }
+  let(:value_args) { double("value args", last: {}) }
 
-  subject { described_class.new(parent_resource, double("value args") ) }
+  let(:uri) { RDF::URI('http://example.org/moomin') }
+
+  subject { described_class.new(parent_resource,  value_args) }
+
+  shared_context 'with URI property' do
+    subject { described_class.new(parent_resource, [property] ) }
+    let(:property) { uri }
+  end
+
+  shared_context 'with symbol property' do
+    subject { described_class.new(parent_resource, [property] ) }
+    let(:property) { :moomin }
+    let(:reflections) do 
+      Class.new do
+        include ActiveTriples::RDFSource
+        property :moomin, predicate: RDF::URI('http://example.org/moomin')
+      end
+    end
+    
+    before do
+      allow(parent_resource).to receive(:reflections).and_return(reflections)
+    end
+  end
+
+  shared_context 'with unregistered property' do
+    subject { described_class.new(parent_resource, [property] ) }
+    let(:property) { :moomin }
+    let(:reflections) { Class.new { include ActiveTriples::RDFSource } }
+    
+    before do
+      allow(parent_resource).to receive(:reflections).and_return(reflections)
+    end
+  end
 
   describe "#predicate" do
-    subject { described_class.new(parent_resource, [predicate] ) }
-
     context 'when the property is an RDF::Term' do
-      let(:predicate) { RDF::URI('http://example.org/moomin') }
-      
+      include_context 'with URI property'
+
       it 'returns the specified RDF::Term' do
-        expect(subject.predicate).to eq predicate
+        expect(subject.predicate).to eq uri
       end
     end
 
     context 'when the property is a symbol' do
-      # unit tests here are hard. There are too many moving parts for something
-      # so simple 
-      it 'returns the reflected property'
+      include_context 'with symbol property'
+
+      it 'returns the reflected property' do
+        expect(subject.predicate).to eq uri
+      end
+    end
+
+    context 'when the symbol property is unregistered' do
+      include_context 'with unregistered property'
+      it 'returns nil' do
+        expect(subject.predicate).to be_nil
+      end
+    end
+  end
+  
+  describe "#property" do
+    context 'when the property is an RDF::Term' do
+      include_context 'with URI property'
+
+      it 'returns the specified RDF::Term' do
+        expect(subject.property).to eq property
+      end
+    end
+
+    context 'when the property is a symbol' do
+      include_context 'with symbol property'
+
+      it 'returns the property symbol' do
+        expect(subject.property).to eq property
+      end
+    end
+
+    context 'when the symbol property is unregistered' do
+      include_context 'with unregistered property'
+
+      it 'returns the property symbol' do
+        expect(subject.property).to eq property
+      end
+    end
+  end
+
+  describe '#result' do
+    context 'with nil predicate' do
+      include_context 'with unregistered property'
+      
+      it 'is empty' do
+        expect(subject.result).to contain_exactly()
+      end
+    end
+    
+    context 'with predicate' do
+      include_context 'with symbol property' do
+        let(:parent_resource) { ActiveTriples::Resource.new }
+      end
+
+      it 'is empty' do
+        expect(subject.result).to contain_exactly()
+      end
+
+      context 'with values' do
+        before do
+          values.each do |value|
+            subject.parent << [subject.parent.rdf_subject, uri, value]
+          end
+        end
+
+        let(:values) { ['Comet in Moominland', 'Finn Family Moomintroll'] }
+        let(:node) { RDF::Node.new }
+
+        it 'contain values' do
+          expect(subject.result).to contain_exactly(*values)
+        end
+
+        context 'with castable values' do
+          let(:values) do
+            [uri, RDF::URI('http://ex.org/too-ticky'), RDF::Node.new]
+          end
+
+          it 'casts Resource values' do
+            expect(subject.result)
+              .to contain_exactly(a_kind_of(ActiveTriples::Resource),
+                                  a_kind_of(ActiveTriples::Resource),
+                                  a_kind_of(ActiveTriples::Resource))
+          end
+
+          it 'cast values have correct URI' do
+            expect(subject.result.map(&:rdf_subject))
+              .to contain_exactly(*values)
+          end
+          
+          context 'when #cast? is false' do
+            let(:values) do
+              [uri, RDF::URI('http://ex.org/too-ticky'), RDF::Node.new,
+              'moomin', Date.today]
+            end
+
+            it 'does not cast results' do
+              allow(subject).to receive(:cast?).and_return(false)
+              expect(subject.result).to contain_exactly(*values)
+            end
+          end
+
+          context 'when #return_literals? is true' do
+            let(:values) do
+              [RDF::Literal('moomin'), RDF::Literal(Date.today)]
+            end
+
+            it 'does not cast results' do
+              allow(subject).to receive(:return_literals?).and_return(true)
+              expect(subject.result).to contain_exactly(*values)
+            end
+          end
+        end
+      end
     end
   end
 

--- a/spec/active_triples/relation_spec.rb
+++ b/spec/active_triples/relation_spec.rb
@@ -166,6 +166,33 @@ describe ActiveTriples::Relation do
     end
   end
 
+  describe '#first_or_create' do
+    let(:parent_resource) { ActiveTriples::Resource.new }
+
+    context 'with symbol' do
+      include_context 'with symbol property'
+      
+      it 'creates a new node' do
+        expect { subject.first_or_create }.to change { subject.count }.by(1)
+      end
+
+      it 'returns existing node if present' do
+        node = subject.build
+        expect(subject.first_or_create).to eq node
+      end
+
+      it 'does not create a new node when one exists' do
+        subject.build
+        expect { subject.first_or_create }.not_to change { subject.count }
+      end
+
+      it 'returns literal value if appropriate' do
+        subject << literal = 'moomin'
+        expect(subject.first_or_create).to eq literal
+      end
+    end
+  end
+
   describe '#result' do
     context 'with nil predicate' do
       include_context 'with unregistered property'

--- a/spec/active_triples/relation_spec.rb
+++ b/spec/active_triples/relation_spec.rb
@@ -111,7 +111,7 @@ describe ActiveTriples::Relation do
     
     it 'is a no-op when relation is empty' do
       subject.parent << [subject.parent.rdf_subject, RDF.type, 'moomin']
-      expect { subject.clear }.not_to change { subject.parent.statements }
+      expect { subject.clear }.not_to change { subject.parent.statements.to_a }
     end
   end
 

--- a/spec/active_triples/relation_spec.rb
+++ b/spec/active_triples/relation_spec.rb
@@ -39,6 +39,37 @@ describe ActiveTriples::Relation do
     end
   end
 
+  describe '#clear' do
+    include_context 'with symbol property'
+    let(:parent_resource) { ActiveTriples::Resource.new }
+
+    context 'with values' do
+      before do
+        subject.parent << [subject.parent.rdf_subject, 
+                           subject.predicate, 
+                           'moomin']
+      end        
+
+      it 'clears the relation' do
+        expect { subject.clear }.to change { subject.result }
+                                     .from(['moomin']).to([])
+      end
+
+      it 'deletes statements from parent' do
+        query_pattern = [subject.parent.rdf_subject, subject.predicate, nil]
+
+        expect { subject.clear }
+          .to change { subject.parent.query(query_pattern) }.to([])
+      end
+    end
+    
+    it 'is a no-op when relation is empty' do
+      subject.parent << [subject.parent.rdf_subject, RDF.type, 'moomin']
+      expect { subject.clear }.not_to change { subject.parent.statements }
+    end
+
+  end
+
   describe "#predicate" do
     context 'when the property is an RDF::Term' do
       include_context 'with URI property'
@@ -271,5 +302,4 @@ describe ActiveTriples::Relation do
       end
     end
   end
-
 end

--- a/spec/active_triples/resource_spec.rb
+++ b/spec/active_triples/resource_spec.rb
@@ -692,25 +692,6 @@ describe ActiveTriples::Resource do
     end
   end
 
-  describe '#rdf_label' do
-    it 'should return an array of label values' do
-      expect(subject.rdf_label).to be_kind_of Array
-    end
-
-    it 'should return the default label values' do
-      subject.title = 'Comet in Moominland'
-      expect(subject.rdf_label).to eq ['Comet in Moominland']
-    end
-
-    it 'should prioritize configured label values' do
-      custom_label = RDF::URI('http://example.org/custom_label')
-      subject.class.configure :rdf_label => custom_label
-      subject << RDF::Statement(subject.rdf_subject, custom_label, RDF::Literal('New Label'))
-      subject.title = 'Comet in Moominland'
-      expect(subject.rdf_label).to eq ['New Label']
-    end
-  end
-
   describe 'editing the graph' do
     it 'should write properties when statements are added' do
       subject << RDF::Statement.new(subject.rdf_subject, RDF::Vocab::DC.title, 'Comet in Moominland')

--- a/spec/active_triples/resource_spec.rb
+++ b/spec/active_triples/resource_spec.rb
@@ -31,6 +31,26 @@ describe ActiveTriples::Resource do
     end
   end
 
+  describe 'setting properties' do
+    before do
+      class DummyWithClass < ActiveTriples::Resource
+        configure :type => RDF::URI('http://example.org/DummyClass')
+      end
+    end
+
+    after { Object.send(:remove_const, "DummyWithClass") }
+
+    it 'should replace property value when Resource class has a rdf type' do
+      dl1 = DummyWithClass.new('http://example.org/dl1')
+      dl2 = DummyWithClass.new('http://example.org/dl2')
+
+      subject.title = dl1
+      expect( subject.title ).to eq [dl1]
+      subject.title = dl2
+      expect( subject.title ).to eq [dl2]
+    end
+  end
+
   describe 'rdf_subject' do
     it "should be a blank node if we haven't set it" do
       expect(subject.rdf_subject.node?).to be true
@@ -633,7 +653,6 @@ describe ActiveTriples::Resource do
         end
       end
     end
-
   end
 
   describe '#[]' do

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec::Matchers.define :be_a_relation_containing do |*expected|
+  match do |actual|
+    expect(actual.class).to eq ActiveTriples::Relation
+    expect(actual).to contain_exactly(*expected)
+    true
+  end
+end
+


### PR DESCRIPTION
In cases where a class with registered RDF type was deleted from a relation, the value would be retained when using `Relation#set`. This removes those conditionals and adds a regression test.