### PR TITLE
Adds a default block to `RDFSource#fetch`

### DIFF
--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -278,14 +278,33 @@ module ActiveTriples
     # and available from property accessors if if predicates are
     # registered.
     #
+    # @example
     #    osu = new('http://dbpedia.org/resource/Oregon_State_University')
     #    osu.fetch
     #    osu.rdf_label.first
     #    # => "Oregon State University"
+    # 
+    # @example with default action block
+    #    my_source = new('http://example.org/dead_url')
+    #    my_source.fetch { |obj| obj.status = 'dead link' }
     #
-    # @return [ActiveTriples::Entity] self
-    def fetch
-      load(rdf_subject)
+    # @yield gives self to block if this is a node, or an error is raised during 
+    #   load
+    # @yieldparam [ActiveTriples::RDFSource] resource  self
+    #
+    # @return [ActiveTriples::RDFSource] self
+    def fetch(&block)
+      begin
+        load(rdf_subject)
+      rescue => e
+        if block_given?
+          yield(self)
+        else
+          raise "#{self} is a blank node; Cannot fetch a resource without a URI" if 
+            node?
+          raise e
+        end
+      end
       self
     end
 

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -112,9 +112,57 @@ describe ActiveTriples::RDFSource do
     end
   end
 
-  describe '#id' do
-  end
+  describe '#fetch' do
+    it 'raises an error when it is a node' do
+      expect { subject.fetch }
+        .to raise_error "#{subject} is a blank node; Cannot fetch a resource " \
+                        'without a URI'
+    end
 
+    context 'with a valid URI' do
+      subject { source_class.new(uri) }
+
+      context 'with a bad link' do
+        before { stub_request(:get, uri).to_return(:status => 404) }
+
+        it 'raises an error if no block is given' do
+          expect { subject.fetch }.to raise_error IOError
+        end
+
+        it 'yields self to block' do
+          expect { |block| subject.fetch(&block) }.to yield_with_args(subject)
+        end
+      end
+
+      context 'with a working link' do
+        before do
+          stub_request(:get, uri).to_return(:status => 200, 
+                                            :body => graph.dump(:ttl))
+        end
+
+        let(:graph) { RDF::Graph.new << statement }
+        let(:statement) { RDF::Statement(subject, RDF::DC.title, 'moomin') }
+
+        it 'loads retrieved graph into its own' do
+          expect { subject.fetch }
+            .to change { subject.statements.to_a }
+                 .from(a_collection_containing_exactly())
+                 .to(a_collection_containing_exactly(statement))
+        end
+        
+        it 'merges retrieved graph into its own' do
+          existing = RDF::Statement(subject, RDF::DC.creator, 'Tove Jansson')
+          subject << existing
+
+          expect { subject.fetch }
+            .to change { subject.statements.to_a }
+                 .from(a_collection_containing_exactly(existing))
+                 .to(a_collection_containing_exactly(statement, existing))
+        end
+      end
+    end
+  end
+  
   describe '#humanize' do
     it 'gives the "" for a node' do
       expect(subject.humanize).to eq ''

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,11 +5,14 @@ require 'bundler/setup'
 Bundler.setup
 
 require 'rdf/spec'
+require 'webmock/rspec'
 require 'active_triples'
 
 require 'pry' unless ENV["CI"]
 
 Dir['./spec/support/**/*.rb'].each { |f| require f }
+
+WebMock.disable_net_connect!
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
`#fetch` yields itself to the block if an error is raised while trying
to `#load`. This closes #53.

As part of the rewrite, a more informative error is thrown when trying
to fetch a bnode; closes #108.