### PR TITLE
Graph#query is faster than using Queryable#query

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec
 
 gem 'pry-byebug' unless ENV["CI"]
+gem 'rdf-spec', github: 'ruby-rdf/rdf-spec', branch: 'develop'

--- a/active-triples.gemspec
+++ b/active-triples.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = "APACHE2"
   s.required_ruby_version     = '>= 1.9.3'
 
-  s.add_dependency('rdf', '~> 1.1.13')
+  s.add_dependency('rdf', '~> 1.1')
   s.add_dependency('linkeddata', '~> 1.1')
   s.add_dependency('activemodel', '>= 3.0.0')
   s.add_dependency('deprecation', '~> 0.1')

--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -74,7 +74,7 @@ module ActiveTriples
       define_model_callbacks :persist
     end
 
-    delegate :each, :load!, :count, :has_statement?, :to => :graph
+    delegate :query, :each, :load!, :count, :has_statement?, :to => :graph
     delegate :to_base, :term?, :escape, :to => :to_term
 
     ##

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -233,6 +233,12 @@ describe ActiveTriples::RDFSource do
   end
 
   describe 'validation' do
+    let(:invalid_statement) do
+      RDF::Statement.from([RDF::Literal.new('blah'), 
+                           RDF::Literal.new('blah'), 
+                           RDF::Literal.new('blah')])
+    end
+      
     it { is_expected.to be_valid }
 
     it 'is valid with valid statements' do
@@ -254,7 +260,7 @@ describe ActiveTriples::RDFSource do
     end
 
     context 'with invalid statement' do
-      before { subject << RDF::Statement.from([nil, nil, nil]) }
+      before { subject << invalid_statement }
 
       it 'is invalid' do
         expect(subject).to be_invalid
@@ -300,7 +306,7 @@ describe ActiveTriples::RDFSource do
         it { is_expected.to be_valid }
 
         context 'and has invaild statements' do
-          before { subject << RDF::Statement.from([nil, nil, nil]) }
+          before { subject << invalid_statement }
 
           it { is_expected.to be_invalid }
 
@@ -308,7 +314,7 @@ describe ActiveTriples::RDFSource do
             expect { subject.valid? }
               .to change { subject.errors.messages }
                    .from({})
-                   .to(include({ title: ["can't be blank"] }))
+                   .to(include({ base: ["The underlying graph must be valid"] }))
           end
         end
       end


### PR DESCRIPTION
Queryable#query filters the result of #each which is calling Graph#query
anyway.