### PR TITLE
Graph#query is faster than using Queryable#query

### DIFF
--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -73,7 +73,7 @@ module ActiveTriples
           graph.valid?
       end
 
-      delegate :each, :load!, :count, :has_statement?, :to => :@graph
+      delegate :query, :each, :load!, :count, :has_statement?, :to => :@graph
 
       define_model_callbacks :persist
 


### PR DESCRIPTION
Queryable#query filters the result of #each which is calling Graph#query
anyway.

This is a backport of #169 to the 0.7 branch.