### PR TITLE
Add `RDFSource#graph_name` since quads aren't returned

### DIFF
--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -207,6 +207,21 @@ module ActiveTriples
     alias_method :to_term, :rdf_subject
 
     ##
+    # Returns `nil` as the `graph_name`. This behavior mimics an `RDF::Graph`
+    # with no graph name, or one without named graph support.
+    #
+    # @note: it's possible to think of an `RDFSource` as "supporting named 
+    #   graphs" in the sense that the `#rdf_subject` is an implied graph name.
+    #   For RDF.rb's purposes, however, it has a nil graph name: when 
+    #   enumerating statements, we treat them as triples.
+    #
+    # @return [nil]
+    # @sse RDF::Graph.graph_name
+    def graph_name
+      nil
+    end
+    
+    ##
     # @return [String] A string identifier for the resource; '' if the
     #   resource is a node
     def humanize
@@ -477,11 +492,11 @@ module ActiveTriples
       end
 
       def default_labels
-        [RDF::SKOS.prefLabel,
-         RDF::DC.title,
+        [RDF::Vocab::SKOS.prefLabel,
+         RDF::Vocab::DC.title,
          RDF::RDFS.label,
-         RDF::SKOS.altLabel,
-         RDF::SKOS.hiddenLabel]
+         RDF::Vocab::SKOS.altLabel,
+         RDF::Vocab::SKOS.hiddenLabel]
       end
 
       ##

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -11,7 +11,7 @@ describe ActiveTriples::RDFSource do
         include ActiveTriples::RDFSource
       end
     end
-    
+
     after { Object.send(:remove_const, :AMLintClass) if defined?(AMLintClass) }
   end
 
@@ -146,12 +146,15 @@ describe ActiveTriples::RDFSource do
 
       context 'with a working link' do
         before do
-          stub_request(:get, uri).to_return(:status => 200, 
+          stub_request(:get, uri).to_return(:status => 200,
                                             :body => graph.dump(:ttl))
         end
 
         let(:graph) { RDF::Graph.new << statement }
-        let(:statement) { RDF::Statement(subject, RDF::DC.title, 'moomin') }
+
+        let(:statement) do
+          RDF::Statement(subject, RDF::Vocab::DC.title, 'moomin')
+        end
 
         it 'loads retrieved graph into its own' do
           expect { subject.fetch }
@@ -159,9 +162,9 @@ describe ActiveTriples::RDFSource do
                  .from(a_collection_containing_exactly())
                  .to(a_collection_containing_exactly(statement))
         end
-        
+
         it 'merges retrieved graph into its own' do
-          existing = RDF::Statement(subject, RDF::DC.creator, 'Tove Jansson')
+          existing = RDF::Statement(subject, RDF::Vocab::DC.creator, 'Tove')
           subject << existing
 
           expect { subject.fetch }
@@ -172,7 +175,13 @@ describe ActiveTriples::RDFSource do
       end
     end
   end
-  
+
+  describe '#graph_name' do
+    it 'returns nil' do
+      expect(subject.graph_name).to be_nil
+    end
+  end
+
   describe '#humanize' do
     it 'gives the "" for a node' do
       expect(subject.humanize).to eq ''
@@ -234,11 +243,11 @@ describe ActiveTriples::RDFSource do
 
   describe 'validation' do
     let(:invalid_statement) do
-      RDF::Statement.from([RDF::Literal.new('blah'), 
-                           RDF::Literal.new('blah'), 
+      RDF::Statement.from([RDF::Literal.new('blah'),
+                           RDF::Literal.new('blah'),
                            RDF::Literal.new('blah')])
     end
-      
+
     it { is_expected.to be_valid }
 
     it 'is valid with valid statements' do
@@ -276,12 +285,12 @@ describe ActiveTriples::RDFSource do
 
     context 'with ActiveModel validation' do
       let(:source_class) do
-        class Validation  
+        class Validation
           include ActiveTriples::RDFSource
 
           validates_presence_of :title
 
-          property :title, predicate: RDF::DC.title
+          property :title, predicate: RDF::Vocab::DC.title
         end
 
         Validation
@@ -326,7 +335,7 @@ describe ActiveTriples::RDFSource do
 
     before do
       class MyDataModel < ActiveTriples::Schema
-        property :test_title, :predicate => RDF::DC.title
+        property :test_title, :predicate => RDF::Vocab::DC.title
       end
     end
 


### PR DESCRIPTION
RDF.rb has a slightly complicated named graph support interface for
Enumerables, which we were not _quite_ meeting, previously.

  - In the default case, we expect an `Enumerable` to contain quads
  as inserted.
  - If the `Enumerable` responds to `#graph_name`, we expect it to
  contain quads as inserted _only when_ the graph name of the statement
  is the same as `#graph_name`.
  - If `#supports?(:graph_name)` is `false` and `#graph_name` is `nil`,
  we expect the `Enumerable` to contain the statements as
  triples (dropping the graph name, but otherwise retaining them).

After looking at this for some time, I don't have any suggestions for
improvements to the `#graph_name` support interface. It *does* seem
vaguely more complicated than necessary, but is also handling complex
issues very simply in the core library.

The approach here is to behave like an `RDF::Graph` with a `nil` graph
name, letting us support arbitrary triple storage without concerning
ourselves about quads.