### PR TITLE
Loosen gemspec requirement for rdf

### DIFF
--- a/active-triples.gemspec
+++ b/active-triples.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = "APACHE2"
   s.required_ruby_version     = '>= 1.9.3'
 
-  s.add_dependency('rdf', '~> 1.1.13')
+  s.add_dependency('rdf', '~> 1.1', '>= 1.1.13')
   s.add_dependency('linkeddata', '~> 1.1')
   s.add_dependency('activemodel', '>= 3.0.0')
   s.add_dependency('deprecation', '~> 0.1')


### PR DESCRIPTION
This allows rdf version 1.99.0 to be used