### PR TITLE
Switching from Array() to Array.wrap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem 'pry-byebug' unless ENV["CI"]
-
-gem 'rdf-spec', :github => 'ruby-rdf/rdf-spec', :branch => 'develop'

--- a/lib/active_triples/configurable.rb
+++ b/lib/active_triples/configurable.rb
@@ -1,4 +1,5 @@
 require 'deprecation'
+require 'active_support/core_ext/array/wrap'
 
 module ActiveTriples
   ##
@@ -61,7 +62,7 @@ module ActiveTriples
     end
 
     def transform_type(values)
-      Array(values).map do |value|
+      Array.wrap(values).map do |value|
         RDF::URI.new(value).tap do |uri|
           RDFSource.type_registry[uri] = self
         end

--- a/lib/active_triples/configuration/merge_item.rb
+++ b/lib/active_triples/configuration/merge_item.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/array/wrap'
+
 module ActiveTriples
   class Configuration
     # Configuration item which sets a value by turning the original into an array and
@@ -6,8 +8,8 @@ module ActiveTriples
     # This enables multiple types to be set on an object, for example.
     class MergeItem < Item
       def set(value)
-        object.inner_hash[key] = Array(object.inner_hash[key])
-        object.inner_hash[key] |= Array(value)
+        object.inner_hash[key] = Array.wrap(object.inner_hash[key])
+        object.inner_hash[key] |= Array.wrap(value)
       end
     end
   end

--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -1,5 +1,6 @@
 require 'active_model'
 require 'active_support/core_ext/hash'
+require 'active_support/core_ext/array/wrap'
 
 module ActiveTriples
   ##
@@ -34,7 +35,7 @@ module ActiveTriples
   # An `RDFSource` is an {RDF::Term}---it can be used as a subject, predicate,
   # object, or context in an {RDF::Statement}.
   #
-  # @todo complete RDF::Value/RDF::Term/RDF::Resource interfaces 
+  # @todo complete RDF::Value/RDF::Term/RDF::Resource interfaces
   #
   # @see ActiveModel
   # @see RDF::Resource
@@ -102,7 +103,7 @@ module ActiveTriples
       reload
 
       # Append type to graph if necessary.
-      Array(self.class.type).each do |type|
+      Array.wrap(self.class.type).each do |type|
         unless self.get_values(:type).include?(type)
           self.get_values(:type) << type
         end
@@ -263,7 +264,7 @@ module ActiveTriples
     # Looks for labels in various default fields, prioritizing
     # configured label fields.
     def rdf_label
-      labels = Array(self.class.rdf_label)
+      labels = Array.wrap(self.class.rdf_label)
       labels += default_labels
       labels.each do |label|
         values = get_values(label)
@@ -494,7 +495,7 @@ module ActiveTriples
 
       ##
       # Apply a predicate mapping using a given strategy.
-      # 
+      #
       # @param [ActiveTriples::Schema, #properties] schema A schema to apply.
       # @param [#apply!] strategy A strategy for applying. Defaults
       #   to ActiveTriples::ExtensionStrategy


### PR DESCRIPTION
The Array coercion is method (i.e. Array()) aggressively attempts to
coerce the object into an Array. A Time object becomes an array of its
constituent numbers (i.e. [CCYY,MM,DD,HH,SS, TZ]). This is not the
desired effect.

Instead, it appears that we are interested in ensuring that a singular
object is wrapped in an Array. Since we are already dependent on
ActiveSupport.

Closes #178