### PR TITLE
Removing OpenStruct in favor of PORO

### DIFF
--- a/lib/active_triples/property.rb
+++ b/lib/active_triples/property.rb
@@ -2,12 +2,42 @@ module ActiveTriples
   ##
   # A value object to encapsulate what a Property is. Instantiate with a hash of
   # options.
-  class Property < OpenStruct
+  #
+  # @todo Should we enforce the interface on the various attributes that are set?
+  class Property
+    def initialize(options = {})
+      self.name = options.fetch(:name)
+      self.attributes = options.except(:name)
+    end
+
+    # @return Symbol
+    attr_reader :name
+
+    # @return Boolean
+    def cast
+      attributes.fetch(:cast, false)
+    end
+
+    # @return Class
+    def class_name
+      attributes[:class_name]
+    end
+
+    # @return RDF::Vocabulary::Term
+    def predicate
+      attributes[:predicate]
+    end
+
+    private
+
+    attr_writer :name
+    attr_accessor :attributes
+
+    alias_method :to_h, :attributes
+
     # Returns the property's configuration values. Will not return #name, which is
     # meant to only be accessible via the accessor.
     # @return [Hash] Configuration values for this property.
-    def to_h
-      super.except(:name)
-    end
+    public :to_h
   end
 end

--- a/spec/active_triples/property_spec.rb
+++ b/spec/active_triples/property_spec.rb
@@ -26,4 +26,17 @@ RSpec.describe ActiveTriples::Property do
       )
     end
   end
+
+  it 'requires a :name' do
+    expect { described_class.new({}) }.to raise_error(KeyError)
+  end
+
+  context '#cast' do
+    it 'has a default of false' do
+      expect(described_class.new(:name => :title).cast).to eq(false)
+    end
+    it 'allows for the default to be overridden' do
+      expect(described_class.new(:name => :title, :cast => true).cast).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
> Ruby's OpenStruct class defines accessor methods dynamically when
> created. This means that the method caches are cleared every time an
> OpenStruct is instantiated.

https://github.com/charliesome/charlie.bz/blob/master/posts/things-that-clear-rubys-method-cache.md

Based on the usage and documentation of ActiveTriples, the Property
class exposes 4 configuration options:

* name
* cast
* class_name
* predicate

Closes #177