### PR TITLE
Avoid circularity in `ParentStrategy`

### DIFF
--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -287,10 +287,11 @@ module ActiveTriples
 
         unless resource.frozen? || 
                resource == parent || 
-               (parent.persistence_strategy.is_a?(ParentStrategy) && 
-                resource == parent.persistence_strategy.final_parent)
+               resource.persistence_strategy.is_a?(ParentStrategy) ||
+               (parent.persistence_strategy.is_a?(ParentStrategy) &&
+                parent.persistence_strategy.ancestors.include?(resource))
           resource.set_persistence_strategy(ParentStrategy)
-          resource.parent = parent 
+          resource.parent = parent
         end
 
         self.node_cache[resource.rdf_subject] = (object ? object : resource)

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'rdf/turtle'
 require 'rdf/spec/enumerable'
 require 'rdf/spec/queryable'
 require 'rdf/spec/countable'
@@ -337,9 +338,8 @@ describe ActiveTriples::RDFSource do
       
       it 'is a no-op' do
         subject << RDF::Statement(subject, RDF::Vocab::DC.title, 'Moomin')
-        # this is a bit naive
         expect { subject.set_value(:not_a_property, '') rescue nil }
-          .not_to change { subject.triples.count }
+          .not_to change { subject.triples.to_a }
       end
     end
     
@@ -449,7 +449,7 @@ describe ActiveTriples::RDFSource do
       let(:document) { source_class.new }
       let(:person) { source_class.new }
 
-      it 'should handle setting reciprocally' do
+      it 'handles setting reciprocally' do
         document.set_value(RDF::Vocab::DC.creator, person)
         person.set_value(RDF::Vocab::FOAF.publications, document)
 
@@ -459,7 +459,7 @@ describe ActiveTriples::RDFSource do
           .to contain_exactly(person)
       end
 
-      it 'should handle setting' do
+      it 'handles setting' do
         document.set_value(RDF::Vocab::DC.creator, person) 
         person.set_value(RDF::Vocab::FOAF.knows, subject) 
         subject.set_value(RDF::Vocab::FOAF.publications, document) 
@@ -473,7 +473,7 @@ describe ActiveTriples::RDFSource do
           .to contain_exactly(person)
       end
 
-      it 'should handle setting circularly' do
+      it 'handles setting circularly' do
         document.set_value(RDF::Vocab::DC.creator, [person, subject])
         person.set_value(RDF::Vocab::FOAF.knows, subject)
 
@@ -481,6 +481,38 @@ describe ActiveTriples::RDFSource do
           .to contain_exactly(person, subject)
         expect(person.get_values(RDF::Vocab::FOAF.knows))
           .to contain_exactly subject
+      end
+
+      it 'handles setting circularly within ancestor list' do
+        person2 = source_class.new
+        subject.set_value(RDF::Vocab::DC.relation, document)
+        document.set_value(RDF::Vocab::DC.relation, person)
+        person.set_value(RDF::Vocab::DC.relation, person2)
+        person2.set_value(RDF::Vocab::DC.relation, document)
+        
+        expect(person.get_values(RDF::Vocab::DC.relation))
+          .to contain_exactly person2
+        expect(person2.get_values(RDF::Vocab::DC.relation))
+          .to contain_exactly document
+      end
+    end
+
+    describe 'capturing child nodes' do
+      let(:other) { source_class.new }
+
+      it 'captures a child node' do
+        expect { subject.set_value(RDF::OWL.sameAs, other) }
+          .to change { other.persistence_strategy }
+               .to(ActiveTriples::ParentStrategy)
+        expect(other.persistence_strategy.parent).to eq subject
+      end
+      
+      it 'does not capture a child node when it already persists to a parent' do
+        third = source_class.new
+        third.set_value(RDF::OWL.sameAs, other)
+
+        expect { subject.set_value(RDF::OWL.sameAs, other) }
+          .not_to change { other.persistence_strategy.parent }
       end
     end
   end


### PR DESCRIPTION
The solution to the circularity problem included here is as follows:

When an `RDFSource` instance is added to a `Relation` it's parent is set
to the `Relation`'s source (confusingly, also called a "parent"; we'll
say "source" for clarity). This happens unless one of the following
holds:

  - the Relation's source is the `RDFSource` being added (i.e. the
    relationship is self-referential).
  - the `RDFSource` is an ancestor of the Relation's source
  - the `RDFSource` instance already has a parent

These constraints rule out the creation of circular parentage
relationships via `#add_child_node`.

When accessing a reloaded child node through a `Relation`, its internal
graph contains the subset of the parent's statements where the subject
is the child node. We can safely continually loop through circular
relations in the graph without causing conflicts. E.g., the following
works without problems:

```ruby
person1.author_of = doc1
doc1.published_by = org1
org1.publishes = person1

person1.author_of
  .first.published_by
  .first.publishes
  .first.author_of
  .first.published_by...
```

Closes #147