### PR TITLE
Change ParentStrategy usage

### DIFF
--- a/lib/active_triples/persistence_strategies/persistence_strategy.rb
+++ b/lib/active_triples/persistence_strategies/persistence_strategy.rb
@@ -23,8 +23,8 @@ module ActiveTriples
     #   deletions in the persisted graph(s).
     # @return [Boolean] true if the resource was sucessfully destroyed
     def destroy(&block)
-      obj.clear
       yield if block_given?
+      obj.clear
       persist!
       @destroyed = true
     end

--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -523,12 +523,6 @@ module ActiveTriples
       end
     end
 
-    def destroy_child(child)
-      statements.each do |statement|
-        delete_statement(statement) if statement.subject == child.rdf_subject || statement.object == child.rdf_subject
-      end
-    end
-
     ##
     # Indicates if the record is 'new' (has not yet been persisted).
     #

--- a/spec/active_triples/identifiable_spec.rb
+++ b/spec/active_triples/identifiable_spec.rb
@@ -141,11 +141,6 @@ describe ActiveTriples::Identifiable do
         it 'has a parent' do
           expect(parent.relation.first.parent).to eq parent
         end
-
-        it 'has a parent after reload' do
-          parent.relation.node_cache = {}
-          expect(parent.relation.first.parent).to eq parent
-        end
       end
     end
 

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -501,19 +501,24 @@ describe ActiveTriples::RDFSource do
     describe 'capturing child nodes' do
       let(:other) { source_class.new }
 
-      it 'captures a child node' do
+      it 'adds child node data to own graph' do
+        other << RDF::Statement(:s, RDF::URI('p'), 'o')
         expect { subject.set_value(RDF::OWL.sameAs, other) }
-          .to change { other.persistence_strategy }
-               .to(ActiveTriples::ParentStrategy)
-        expect(other.persistence_strategy.parent).to eq subject
+          .to change { subject.statements.to_a }.to include(*other.statements.to_a)
+      end
+
+      it 'does not change persistence strategy of added node' do
+        expect { subject.set_value(RDF::OWL.sameAs, other) }
+          .not_to change { other.persistence_strategy }
       end
       
       it 'does not capture a child node when it already persists to a parent' do
         third = source_class.new
         third.set_value(RDF::OWL.sameAs, other)
-
-        expect { subject.set_value(RDF::OWL.sameAs, other) }
-          .not_to change { other.persistence_strategy.parent }
+        
+        child_other = third.get_values(RDF::OWL.sameAs).first
+        expect { subject.set_value(RDF::OWL.sameAs, child_other) }
+          .not_to change { child_other.persistence_strategy.parent }
       end
     end
   end

--- a/spec/active_triples/resource_spec.rb
+++ b/spec/active_triples/resource_spec.rb
@@ -342,24 +342,21 @@ describe ActiveTriples::Resource do
     end
 
     context 'with a parent' do
-      before do
-        parent.license = subject
-      end
+      before { parent.license = subject }
 
       let(:parent) do
         DummyResource.new('http://example.org/moomi')
       end
 
-      it 'should empty the graph and remove it from the parent' do
-        subject.destroy
-        expect(parent.license).to be_empty
+      it 'empties the graph and removes it from the parent' do
+        expect { parent.license.first.destroy! }
+          .to change { parent.license.empty? }.to true
       end
 
-      it 'should remove its whole graph from the parent' do
-        subject.destroy
-        subject.each_statement do |s|
-          expect(parent.statements).not_to include s
-        end
+      it 'removes its whole graph from the parent' do
+        statements = subject.statements.to_a
+        parent.license.first.destroy
+        statements.each { |s| expect(parent.statements).not_to include s }
       end
     end
   end

--- a/spec/support/dummies/basic_persistable.rb
+++ b/spec/support/dummies/basic_persistable.rb
@@ -1,14 +1,4 @@
 # frozen_string_literal: true
 class BasicPersistable
-  include ActiveTriples::Persistable
-
-  attr_reader :graph
-
-  def initialize
-    @graph = RDF::Graph.new
-  end
-
-  def rdf_subject
-    RDF::Node.new
-  end
+  include ActiveTriples::RDFSource
 end


### PR DESCRIPTION
This avoids changing the persistence strategy of a given `RDFSource`
instance when setting a value. Instead, we only use `ParentStrategy` when
a resource is accessed through `#get_values`.

Closes #186