### PR TITLE
Refactor / clean up PersistenceStrategy

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,9 +1,8 @@
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 
-guard :rspec do
+guard :rspec, cmd: "bundle exec rspec" do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec" }
 end
-

--- a/lib/active_triples/persistence_strategies/parent_strategy.rb
+++ b/lib/active_triples/persistence_strategies/parent_strategy.rb
@@ -43,7 +43,7 @@ module ActiveTriples
           statement.object == obj.rdf_subject
       end
 
-      super 
+      super { obj.clear }
     end
 
     ##

--- a/lib/active_triples/persistence_strategies/parent_strategy.rb
+++ b/lib/active_triples/persistence_strategies/parent_strategy.rb
@@ -21,7 +21,7 @@ module ActiveTriples
     end
 
     ##
-    # Objects using this strategy are persisted only if their parent is also 
+    # Resources using this strategy are persisted only if their parent is also 
     # persisted.
     #
     # @see PersistenceStrategy#persisted?
@@ -47,8 +47,9 @@ module ActiveTriples
     end
 
     ##
-    # Clear out any old assertions in the repository about this node or statement
-    # thus preparing to receive the updated assertions.
+    # @abstract Clear out any old assertions in the datastore / repository 
+    # about this node  or statement thus preparing to receive the updated 
+    # assertions.
     def erase_old_resource
       final_parent.statements.each do |statement|
         final_parent.send(:delete_statement, statement) if
@@ -65,7 +66,7 @@ module ActiveTriples
     ##
     # @return [#persist!] the last parent in a chain from `parent` (e.g.
     #   the parent's parent's parent). This is the RDF::Mutable that the
-    #   object will project itself on when persisting.
+    #   resource will project itself on when persisting.
     def final_parent
       ancestors.to_a.last
     end
@@ -82,7 +83,7 @@ module ActiveTriples
     end
 
     ##
-    # Persists the object to the final parent.
+    # Persists the resource to the final parent.
     #
     # @return [true] true if the save did not error
     def persist!
@@ -102,7 +103,7 @@ module ActiveTriples
     end
 
     ##
-    # An enumerable over the ancestors of an object
+    # An enumerable over the ancestors of an resource
     class Ancestors
       include Enumerable
 

--- a/lib/active_triples/persistence_strategies/persistence_strategy.rb
+++ b/lib/active_triples/persistence_strategies/persistence_strategy.rb
@@ -24,6 +24,13 @@ module ActiveTriples
     # @return [Boolean] true if the resource was sucessfully destroyed
     def destroy(&block)
       yield if block_given?
+      
+      # Provide a warning for strategies relying on #destroy to clear the resource
+      if defined? obj
+        warn "DEPRECATION WARNING: #destroy implementations must now explicitly call 'source.clear'"
+        obj.clear
+      end
+      
       persist!
       @destroyed = true
     end

--- a/lib/active_triples/persistence_strategies/persistence_strategy.rb
+++ b/lib/active_triples/persistence_strategies/persistence_strategy.rb
@@ -24,7 +24,6 @@ module ActiveTriples
     # @return [Boolean] true if the resource was sucessfully destroyed
     def destroy(&block)
       yield if block_given?
-      obj.clear
       persist!
       @destroyed = true
     end

--- a/lib/active_triples/persistence_strategies/persistence_strategy.rb
+++ b/lib/active_triples/persistence_strategies/persistence_strategy.rb
@@ -3,7 +3,7 @@ module ActiveTriples
   ##
   # @abstract defines the basic interface for persistence of {RDFSource}'s.
   #
-  # A `PersistenceStrategy` has an underlying object (`obj`) which should 
+  # A `PersistenceStrategy` has an underlying resource which should 
   # be an `RDFSource` or equivalent. Strategies can be injected into `RDFSource`
   # instances at runtime to change the target datastore, repository, or object 
   # the instance syncs its graph with on save and reload operations.
@@ -17,7 +17,7 @@ module ActiveTriples
   #
   module PersistenceStrategy
     ##
-    # Deletes the resource from the repository.
+    # Deletes the resource from the datastore / repository.
     #
     # @yield prior to persisting, yields to allow a block that performs
     #   deletions in the persisted graph(s).
@@ -38,7 +38,7 @@ module ActiveTriples
     end
 
     ##
-    # Indicates if the resource is persisted to the repository
+    # Indicates if the resource is persisted to the datastore / repository
     #
     # @return [Boolean] true if persisted; else false.
     def persisted?
@@ -46,7 +46,7 @@ module ActiveTriples
     end
 
     ##
-    # @abstract save the object according to the strategy and set the 
+    # @abstract save the resource according to the strategy and set the 
     #   @persisted flag to `true`
     #
     # @see #persisted?
@@ -57,8 +57,9 @@ module ActiveTriples
     end
 
     ##
-    # @abstract Clear out any old assertions in the repository about this node 
-    # or statement thus preparing to receive the updated assertions.
+    # @abstract Clear out any old assertions in the datastore / repository 
+    # about this node  or statement thus preparing to receive the updated 
+    # assertions.
     #
     # @return [Boolean]
     def erase_old_resource

--- a/lib/active_triples/persistence_strategies/repository_strategy.rb
+++ b/lib/active_triples/persistence_strategies/repository_strategy.rb
@@ -17,6 +17,13 @@ module ActiveTriples
     end
 
     ##
+    # Deletes the resource from the repository.
+    #
+    def destroy
+      super { obj.clear }
+    end
+
+    ##
     # Clear out any old assertions in the repository about this node or statement
     # thus preparing to receive the updated assertions.
     def erase_old_resource

--- a/lib/active_triples/persistence_strategies/repository_strategy.rb
+++ b/lib/active_triples/persistence_strategies/repository_strategy.rb
@@ -5,35 +5,35 @@ module ActiveTriples
   class RepositoryStrategy
     include PersistenceStrategy
 
-    # @!attribute [r] obj
-    #   the source to persist with this strategy
-    attr_reader :obj
+    # @!attribute [r] source
+    #   the resource to persist with this strategy
+    attr_reader :source
 
     ##
-    # @param obj [RDFSource, RDF::Enumerable] the `RDFSource` (or other
+    # @param source [RDFSource, RDF::Enumerable] the `RDFSource` (or other
     #   `RDF::Enumerable` to persist with the strategy.
-    def initialize(obj)
-      @obj = obj
+    def initialize(source)
+      @source = source
     end
 
     ##
     # Deletes the resource from the repository.
     #
     def destroy
-      super { obj.clear }
+      super { source.clear }
     end
 
     ##
     # Clear out any old assertions in the repository about this node or statement
     # thus preparing to receive the updated assertions.
     def erase_old_resource
-      if obj.node?
+      if source.node?
         repository.statements.each do |statement|
           repository.send(:delete_statement, statement) if
-            statement.subject == obj
+            statement.subject == source
         end
       else
-        repository.delete [obj.to_term, nil, nil]
+        repository.delete [source.to_term, nil, nil]
       end
     end
 
@@ -43,7 +43,7 @@ module ActiveTriples
     # @return [true] returns true if the save did not error
     def persist!
       erase_old_resource
-      repository << obj
+      repository << source
       @persisted = true
     end
 
@@ -52,8 +52,8 @@ module ActiveTriples
     #
     # @return [Boolean]
     def reload
-      obj << repository.query(subject: obj)
-      @persisted = true unless obj.empty?
+      source << repository.query(subject: source)
+      @persisted = true unless source.empty?
       true
     end
 
@@ -74,9 +74,9 @@ module ActiveTriples
       # @todo find a way to move this logic out (PersistenceStrategyBuilder?).
       #   so the dependency on Repositories is externalized.
       def set_repository
-        return RDF::Repository.new if obj.class.repository.nil?
-        repo = Repositories.repositories[obj.class.repository]
-        repo || raise(RepositoryNotFoundError, "The class #{obj.class} expects a repository called #{obj.class.repository}, but none was declared")
+        return RDF::Repository.new if source.class.repository.nil?
+        repo = Repositories.repositories[source.class.repository]
+        repo || raise(RepositoryNotFoundError, "The class #{source.class} expects a repository called #{source.class.repository}, but none was declared")
       end
   end
 end

--- a/lib/active_triples/persistence_strategies/repository_strategy.rb
+++ b/lib/active_triples/persistence_strategies/repository_strategy.rb
@@ -38,7 +38,7 @@ module ActiveTriples
     end
 
     ##
-    # Persists the object to the repository
+    # Persists the resource to the repository
     #
     # @return [true] returns true if the save did not error
     def persist!
@@ -58,7 +58,7 @@ module ActiveTriples
     end
 
     ##
-    # @return [RDF::Repository] The RDF::Repository that the object will project
+    # @return [RDF::Repository] The RDF::Repository that the resource will project
     #   itself on when persisting.
     def repository
       @repository ||= set_repository
@@ -67,7 +67,7 @@ module ActiveTriples
     private
 
       ##
-      # Finds an appropriate repository from the calling object's configuration.
+      # Finds an appropriate repository from the calling resource's configuration.
       # If no repository is configured, builds an ephemeral in-memory
       # repository and 'persists' there.
       #

--- a/spec/active_triples/persistence_strategies/parent_strategy_spec.rb
+++ b/spec/active_triples/persistence_strategies/parent_strategy_spec.rb
@@ -53,8 +53,8 @@ describe ActiveTriples::ParentStrategy do
     end
     
     let(:statements) do
-      [RDF::Statement(subject.obj.rdf_subject, RDF::Vocab::DC.title, 'moomin'),
-       RDF::Statement(:node, RDF::Vocab::DC.relation, subject.obj.rdf_subject),
+      [RDF::Statement(subject.source.rdf_subject, RDF::Vocab::DC.title, 'moomin'),
+       RDF::Statement(:node, RDF::Vocab::DC.relation, subject.source.rdf_subject),
        RDF::Statement(:node, RDF::Vocab::DC.relation, :other_node)]
     end
 

--- a/spec/active_triples/persistence_strategies/repository_strategy_spec.rb
+++ b/spec/active_triples/persistence_strategies/repository_strategy_spec.rb
@@ -66,7 +66,7 @@ describe ActiveTriples::RepositoryStrategy do
 
       context 'with subjects' do
         before do
-          subject.obj.set_subject! RDF::URI('http://example.org/moomin')
+          subject.source.set_subject! RDF::URI('http://example.org/moomin')
         end
 
         include_examples 'destroy resource'

--- a/spec/support/shared_examples/persistence_strategy.rb
+++ b/spec/support/shared_examples/persistence_strategy.rb
@@ -2,7 +2,7 @@
 shared_examples 'a persistence strategy' do
   shared_context 'with changes' do
     before do
-      subject.obj << 
+      subject.source << 
         RDF::Statement.new(RDF::Node.new, RDF::Vocab::DC.title, 'moomin')
     end
   end


### PR DESCRIPTION
Major goals:

1) Rename references to `@obj` to `@source` to better reflect that the `Persistable` is a `RDFSource` or similar; not an object within a graph.  This is particularly important with `ParentStrategy`, eg.

> delete obj.statements from final_parent AND delete all statements in parent that have obj.rdf_subject as subject or object

2) Decouple reference to `@obj` in the abstract module, since it's not necessarily defined by subclassing strategies.  This required moving some code into `RepositoryStrategy#destroy` and `ParentStrategy#destroy` and some warning code, but the alternative is to require injecting a `Persistable` in the initializer, which seemed more cumbersome.

Thoughts and comments welcomed.