### PR TITLE
FIX #200 Use == instead of eql? for resource equality test

### DIFF
--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -287,7 +287,7 @@ module ActiveTriples
         resource = resource.dup
         unless resource == parent || 
                (parent.persistence_strategy.is_a?(ParentStrategy) &&
-                parent.persistence_strategy.ancestors.find { |a| a.eql? resource })
+                parent.persistence_strategy.ancestors.find { |a| a == resource })
           resource.set_persistence_strategy(ParentStrategy)
           resource.parent = parent
         end

--- a/spec/integration/dummies/dummy_resource_a.rb
+++ b/spec/integration/dummies/dummy_resource_a.rb
@@ -1,0 +1,6 @@
+class DummyResourceA
+  include ActiveTriples::RDFSource
+  configure :type => RDF::URI('http://example.org/type/ResourceA')
+  property :label, :predicate => RDF::URI('http://example.org/ontology/label')
+  property :has_resource, :predicate => RDF::URI('http://example.org/ontology/has_resource'), :class_name => DummyResourceB
+end

--- a/spec/integration/dummies/dummy_resource_b.rb
+++ b/spec/integration/dummies/dummy_resource_b.rb
@@ -1,0 +1,6 @@
+class DummyResourceB
+  include ActiveTriples::RDFSource
+  configure :type => RDF::URI('http://example.org/type/ResourceB')
+  property :label, :predicate => RDF::URI('http://example.org/ontology/label')
+  property :in_resource, :predicate => RDF::URI('http://example.org/ontology/in_resource'), :class_name => DummyResourceA
+end

--- a/spec/integration/reciprocal_properties_spec.rb
+++ b/spec/integration/reciprocal_properties_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+autoload :DummyResourceA, 'integration/dummies/dummy_resource_a'
+autoload :DummyResourceB, 'integration/dummies/dummy_resource_b'
+
+describe 'reciprocal properties' do
+  context 'when using repository strategy for all' do
+    before do
+      ActiveTriples::Repositories.add_repository :default, RDF::Repository.new
+    end
+
+    let (:a) do
+      # a = DummyResourceA.new(RDF::URI('http://example.com/a'))
+      a = DummyResourceA.new
+      a.label = 'resource A'
+      a
+    end
+
+    let (:b) do
+      # b = DummyResourceB.new(RDF::URI('http://example.com/b'))
+      b = DummyResourceB.new
+      b.label = 'resource B'
+      b
+    end
+
+    it 'should allow A -> B -> A' do
+      expect(a.persistence_strategy).to be_kind_of ActiveTriples::RepositoryStrategy
+      expect(b.persistence_strategy).to be_kind_of ActiveTriples::RepositoryStrategy
+
+      a.has_resource = b
+      expect(a.has_resource).to eq [b]
+      expect(a.label).to eq ['resource A']
+      expect(b.label).to eq ['resource B']
+
+      b.in_resource = a
+      expect(b.in_resource).to eq [a]
+      expect(a.label).to eq ['resource A']
+      expect(b.label).to eq ['resource B']
+    end
+  end
+
+  context 'when using parent_strategy for some' do
+    let (:a) do
+      d = DummyResourceA.new(RDF::URI('http://example.com/a'))
+      d.label = 'resource A'
+      d
+    end
+
+    let (:b) do
+      p = DummyResourceB.new(RDF::URI('http://example.com/b'),a)
+      p.label = 'resource B'
+      p
+    end
+
+    it 'should allow A -> B -> A' do
+      expect(a.persistence_strategy).to be_kind_of ActiveTriples::RepositoryStrategy
+      expect(b.persistence_strategy).to be_kind_of ActiveTriples::ParentStrategy
+
+      a.has_resource = b
+      expect(a.has_resource).to eq [b]
+      expect(a.label).to eq ['resource A']
+      expect(b.label).to eq ['resource B']
+
+      b.in_resource = a
+      expect(b.in_resource).to eq [a]
+      expect(a.label).to eq ['resource A']
+      expect(b.label).to eq ['resource B']
+    end
+  end
+end


### PR DESCRIPTION
Adds fix and tests for reciprocal relationship A -> B -> A

A.has_resource = B
B.in_resource = A

See issue #200 for more information.