### PR TITLE
Do not include all predicates in unregistered_predicates

### DIFF
--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -586,9 +586,11 @@ module ActiveTriples
       #
       # @return [Array<RDF::URI>]
       def unregistered_predicates
-        preds = registered_predicates
-        preds << RDF.type
-        predicates.select { |p| !preds.include? p }
+        registered_preds = registered_predicates
+        registered_preds << RDF.type
+        unregistered_preds = []
+        each_statement { |s,p,o| unregistered_preds << p unless (s != rdf_subject) || (registered_preds.include? p) }
+        unregistered_preds
       end
 
       def default_labels

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -171,6 +171,17 @@ describe ActiveTriples::RDFSource do
         expect(subject.attributes['creator']).to contain_exactly 'moomin'
       end
     end
+
+    context 'with statements for other subjects' do
+      before do
+        subject << RDF::Statement(RDF::URI('http://example.org/OTHER_SUBJECT'), RDF::URI('http://example.org/ontology/OTHER_PRED'), 'OTHER_OBJECT')
+      end
+
+      it "should not include predicate-values for statements with rdf_subject != this object's rdf_subject" do
+        expect(subject.attributes.keys).not_to include 'http://example.org/ontology/OTHER_PRED'
+        expect(subject.attributes.values).not_to include ['OTHER_OBJECT']
+      end
+    end
   end
 
   describe '#fetch' do


### PR DESCRIPTION
Do not include predicates in unregistered_predicates that have a different subject from the resource.

Fixes #206 