### PR TITLE
Upgrade Ruby RDF versions to 2.0

### DIFF
--- a/active-triples.gemspec
+++ b/active-triples.gemspec
@@ -7,27 +7,27 @@ Gem::Specification.new do |s|
   s.version     = ActiveTriples::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Tom Johnson", "Trey Terrell"]
-  s.homepage    = 'https://github.com/no-reply/ActiveTriples'
+  s.homepage    = 'https://github.com/ActiveTriples/ActiveTriples'
   s.email       = 'tom@dp.la'
   s.summary     = %q{RDF graphs in ActiveModel wrappers.}
   s.description = %q{ActiveTriples provides tools for modeling RDF as discrete resources.}
   s.license     = "APACHE2"
-  s.required_ruby_version     = '>= 1.9.3'
+  s.required_ruby_version     = '>= 2.0.0'
 
-  s.add_dependency('rdf', '1.99')
-  s.add_dependency('linkeddata', '~> 1.99')
-  s.add_dependency('activemodel', '>= 3.0.0')
-  s.add_dependency('deprecation', '~> 0.1')
-  s.add_dependency('activesupport', '>= 3.0.0')
+  s.add_dependency 'rdf',           '~> 2.0'
+  s.add_dependency 'linkeddata',    '~> 2.0'
+  s.add_dependency 'activemodel',   '>= 3.0.0'
+  s.add_dependency 'deprecation',   '~> 0.1'
+  s.add_dependency 'activesupport', '>= 3.0.0'
 
-  s.add_development_dependency('rdoc')
-  s.add_development_dependency('rspec')
-  s.add_development_dependency('rdf-spec', '~> 1.99')
-  s.add_development_dependency('coveralls')
-  s.add_development_dependency('guard-rspec')
-  s.add_development_dependency('webmock')
-  s.add_development_dependency('nokogiri')
-  s.add_development_dependency('pragmatic_context', '~> 0.1.2')
+  s.add_development_dependency 'rdoc'
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rdf-spec', '~> 2.0'
+  s.add_development_dependency 'coveralls'
+  s.add_development_dependency 'guard-rspec'
+  s.add_development_dependency 'webmock'
+  s.add_development_dependency 'nokogiri'
+  s.add_development_dependency 'pragmatic_context', '~> 0.1.2'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec}/*`.split("\n")

--- a/active-triples.gemspec
+++ b/active-triples.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rdf-spec', '~> 2.0'
   s.add_development_dependency 'coveralls'
-  s.add_development_dependency 'guard-rspec'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'nokogiri'
   s.add_development_dependency 'pragmatic_context', '~> 0.1.2'

--- a/lib/active_triples/list.rb
+++ b/lib/active_triples/list.rb
@@ -18,7 +18,7 @@ module ActiveTriples
     class << self
       def from_uri(uri, vals)
         list = ListResource.from_uri(uri, vals)
-        self.new(list.rdf_subject, list)
+        self.new(subject: list.rdf_subject, graph: list)
       end
     end
 
@@ -26,13 +26,13 @@ module ActiveTriples
       graph
     end
 
-    def initialize(*args)
+    def initialize(subject: nil, graph: nil, values: nil, &block)
       super
       @graph = ListResource.new(subject) unless
         graph.kind_of? RDFSource
-      graph << parent if parent
-      graph.list = self
-      graph.reload
+      @graph << parent if parent
+      @graph.list = self
+      @graph.reload
     end
 
     def clear
@@ -124,7 +124,7 @@ module ActiveTriples
       # Clear out any old assertions in the repository about this node or statement
       # thus preparing to receive the updated assertions.
       def erase_old_resource
-        RDF::List.new(rdf_subject, self).clear
+        RDF::List.new(subject: rdf_subject, graph: self).clear
       end
 
       private

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -241,7 +241,7 @@ module ActiveTriples
     def delete?(value)
       value = RDF::Literal(value) if value.is_a? Symbol
 
-      return nil if parent.query([rdf_subject, predicate, value]).empty?
+      return nil if parent.query([rdf_subject, predicate, value]).nil?
 
       delete(value)
       value

--- a/spec/active_triples/list_spec.rb
+++ b/spec/active_triples/list_spec.rb
@@ -249,12 +249,12 @@ END
           expect(doc.xpath('//mads:ComplexSubject/mads:elementList/*[position() = 2]/mads:elementValue', ns).map(&:text)).to eq ["Relations with Mexican Americans"]
           expect(doc.xpath('//mads:ComplexSubject/mads:elementList/*[position() = 3]/@rdf:about', ns).map(&:value)).to eq ["http://library.ucsd.edu/ark:/20775/bbXXXXXXX4"]
           expect(doc.xpath('//mads:ComplexSubject/mads:elementList/*[position() = 4]/mads:elementValue', ns).map(&:text)).to eq ["1900s"]
-          expect(RDF::List.new(list.rdf_subject, subject)).to be_valid
+          expect(RDF::List.new(subject: list.rdf_subject, graph: subject)).to be_valid
         end
 
         it "should be a valid list" do
           list << "Val"
-          expect(RDF::List.new(list.rdf_subject, subject)).to be_valid
+          expect(RDF::List.new(subject: list.rdf_subject, graph: subject)).to be_valid
         end
       end
     end

--- a/spec/active_triples/nested_attributes_spec.rb
+++ b/spec/active_triples/nested_attributes_spec.rb
@@ -105,14 +105,18 @@ describe "nesting attribute behavior" do
         subject { ComplexResource::PersonalName.new }
         it "should accept a hash" do
           subject.elementList_attributes =  [{ topicElement_attributes: {'0' => { elementValue:"Quantum Behavior" }, '1' => { elementValue:"Wave Function" }}}]
-          expect(subject.elementList.first[0].elementValue).to eq ["Quantum Behavior"]
-          expect(subject.elementList.first[1].elementValue).to eq ["Wave Function"]
-
+          expect(subject.elementList.first[0].elementValue)
+            .to contain_exactly "Quantum Behavior"
+          expect(subject.elementList.first[1].elementValue)
+            .to contain_exactly "Wave Function"
         end
+
         it "should accept an array" do
           subject.elementList_attributes =  [{ topicElement_attributes: [{ elementValue:"Quantum Behavior" }, { elementValue:"Wave Function" }]}]
-          expect(subject.elementList.first[0].elementValue).to eq ["Quantum Behavior"]
-          expect(subject.elementList.first[1].elementValue).to eq ["Wave Function"]
+          expect(subject.elementList.first[0].elementValue)
+            .to contain_exactly "Quantum Behavior"
+          expect(subject.elementList.first[1].elementValue)
+            .to contain_exactly "Wave Function"
         end
       end
 
@@ -123,15 +127,19 @@ describe "nesting attribute behavior" do
         end
 
         it 'should have attributes' do
-          expect(subject.topic[0].elementList.first[0].elementValue).to eq ["Cosmology"]
-          expect(subject.topic[1].elementList.first[0].elementValue).to eq ["Quantum Behavior"]
-          expect(subject.personalName.first.elementList.first.fullNameElement).to eq ["Jefferson, Thomas"]
-          expect(subject.personalName.first.elementList.first.dateNameElement).to eq ["1743-1826"]
+          expect(subject.topic.map { |topic| topic.elementList.first[0].elementValue })
+            .to contain_exactly ['Cosmology'], ['Quantum Behavior']
+          expect(subject.personalName.first.elementList.first.fullNameElement)
+            .to contain_exactly "Jefferson, Thomas"
+          expect(subject.personalName.first.elementList.first.dateNameElement)
+            .to contain_exactly "1743-1826"
         end
 
         it 'should build nodes with ids' do
-          expect(subject.topic[0].elementList.first[0].rdf_subject).to eq 'http://library.ucsd.edu/ark:/20775/bb3333333x'
-          expect(subject.personalName.first.rdf_subject).to eq  'http://library.ucsd.edu/ark:20775/jefferson'
+          expect(subject.topic.map { |v| v.elementList.first[0].rdf_subject })
+            .to include 'http://library.ucsd.edu/ark:/20775/bb3333333x'
+          expect(subject.personalName.map(&:rdf_subject))
+            .to include 'http://library.ucsd.edu/ark:20775/jefferson'
         end
 
         it 'should fail when writing to a non-predicate' do
@@ -186,7 +194,9 @@ describe "nesting attribute behavior" do
                                   { id: remove_object_id, _destroy: '1', label: "bar1 uno" }] }
 
           it "should update nested objects" do
-            expect(subject.parts.map{|p| p.label.first}).to eq ['Alternator', 'Universal Joint', 'Transmission', 'Oil Pump']
+            expect(subject.parts.map{|p| p.label.first})
+              .to contain_exactly 'Universal Joint', 'Oil Pump', 
+                                  an_instance_of(String), an_instance_of(String)
           end
         end
 
@@ -194,7 +204,8 @@ describe "nesting attribute behavior" do
           let(:new_attributes) { [{ id: 'http://example.com/part#1', label: "Universal Joint" }] }
 
           it "creates a new statement" do
-            expect(subject.parts.last.rdf_subject).to eq RDF::URI('http://example.com/part#1')
+            expect(subject.parts.map(&:rdf_subject))
+              .to include RDF::URI('http://example.com/part#1')
           end
         end
       end
@@ -214,7 +225,10 @@ describe "nesting attribute behavior" do
                                 { id: 'http://id.loc.gov/authorities/subjects/sh85052223' }] }
 
         it "should update nested objects" do
-          expect(subject.parts.map{|p| p.id}).to eq ["http://id.loc.gov/authorities/subjects/sh85010251", "http://id.loc.gov/authorities/subjects/sh2001009145", "http://id.loc.gov/authorities/subjects/sh85052223"]
+          expect(subject.parts.map{|p| p.id})
+            .to contain_exactly "http://id.loc.gov/authorities/subjects/sh85010251", 
+                                "http://id.loc.gov/authorities/subjects/sh2001009145", 
+                                "http://id.loc.gov/authorities/subjects/sh85052223"
         end
       end
 
@@ -227,7 +241,8 @@ describe "nesting attribute behavior" do
           before { subject.parts_attributes = new_attributes }
 
           it "should call the reject if proc" do
-            expect(subject.parts.map(&:label)).to eq [['Universal Joint']]
+            expect(subject.parts.map(&:label))
+              .to contain_exactly(['Universal Joint'])
           end
         end
       end

--- a/spec/active_triples/property_spec.rb
+++ b/spec/active_triples/property_spec.rb
@@ -6,14 +6,14 @@ describe ActiveTriples::Property do
   let(:options) do
     {
       :name => :title,
-      :predicate => RDF::DC.title,
+      :predicate => RDF::Vocab::DC.title,
       :class_name => "Test"
     }
   end
 
   it "should create accessors for each passed option" do
     expect(subject.name).to eq :title
-    expect(subject.predicate).to eq RDF::DC.title
+    expect(subject.predicate).to eq RDF::Vocab::DC.title
     expect(subject.class_name).to eq "Test"
   end
 
@@ -21,7 +21,7 @@ describe ActiveTriples::Property do
     it "should not return the property's name" do
       expect(subject.to_h).to eq (
         {
-          :predicate => RDF::DC.title,
+          :predicate => RDF::Vocab::DC.title,
           :class_name => "Test"
         }
       )

--- a/spec/active_triples/relation_spec.rb
+++ b/spec/active_triples/relation_spec.rb
@@ -530,13 +530,17 @@ describe ActiveTriples::Relation do
 
       context 'with values' do
         let(:values) { ['Comet in Moominland', 'Finn Family Moomintroll'] }
+
         before do
           values.each do |value|
             subject.parent << [subject.parent.rdf_subject, uri, value]
           end
         end
+
         it "returns joined strings" do
-          expect(subject.join(", ")).to eq "Comet in Moominland, Finn Family Moomintroll"
+          expect(subject.join(", "))
+            .to satisfy { |v| sp = v.split(', ').include?("Comet in Moominland") &&
+                          v.split(', ').include?("Finn Family Moomintroll") }
         end
       end
     end

--- a/spec/active_triples/resource_spec.rb
+++ b/spec/active_triples/resource_spec.rb
@@ -504,7 +504,8 @@ describe ActiveTriples::Resource do
       vals = subject.get_values('license')
       vals << "foo"
       subject.set_value('license',vals)
-      expect(subject.get_values('license')).to eq ["foo"]
+      expect(subject.get_values('license'))
+        .to contain_exactly "foo"
     end
 
     it "safely handles terms passed in with pre-existing values" do
@@ -512,12 +513,14 @@ describe ActiveTriples::Resource do
       vals = subject.get_values('license')
       vals << "bar"
       subject.set_value('license',vals)
-      expect(subject.get_values('license')).to eq ["foo","bar"]
+      expect(subject.get_values('license'))
+        .to contain_exactly "foo","bar"
     end
 
     it 'should set a value in the when given a registered property symbol' do
       subject.set_value(:title, 'Comet in Moominland')
-      expect(subject.title).to eq ['Comet in Moominland']
+      expect(subject.title)
+        .to contain_exactly 'Comet in Moominland'
     end
 
     it "raise an error if the value is not a Term" do
@@ -541,7 +544,7 @@ describe ActiveTriples::Resource do
 
     it 'should set a value in the when given a registered property symbol' do
       subject[:title] = 'Comet in Moominland'
-      expect(subject.title).to eq ['Comet in Moominland']
+      expect(subject.title).to contain_exactly 'Comet in Moominland'
     end
 
     it "raise an error if the value is not a URI, Node, Literal, RdfResource, or string" do
@@ -556,17 +559,21 @@ describe ActiveTriples::Resource do
     end
 
     it 'should return values for a predicate uri' do
-      expect(subject.get_values(RDF::Vocab::DC.title)).to eq ['Comet in Moominland', 'Finn Family Moomintroll']
+      expect(subject.get_values(RDF::Vocab::DC.title))
+        .to contain_exactly 'Comet in Moominland', 'Finn Family Moomintroll'
     end
 
     it 'should return values for a registered predicate symbol' do
-      expect(subject.get_values(:title)).to eq ['Comet in Moominland', 'Finn Family Moomintroll']
+      expect(subject.get_values(:title))
+        .to contain_exactly 'Comet in Moominland', 'Finn Family Moomintroll'
     end
 
     it "should return values for other subjects if asked" do
       expect(subject.get_values(RDF::URI("http://opaquenamespace.org/jokes"),:title)).to eq []
       subject.set_value(RDF::URI("http://opaquenamespace.org/jokes"), RDF::Vocab::DC.title, 'Comet in Moominland')
-      expect(subject.get_values(RDF::URI("http://opaquenamespace.org/jokes"),:title)).to eq ["Comet in Moominland"]
+
+      expect(subject.get_values(RDF::URI("http://opaquenamespace.org/jokes"),:title))
+        .to contain_exactly "Comet in Moominland"
     end
 
     context "literals are set" do
@@ -578,12 +585,14 @@ describe ActiveTriples::Resource do
       context "and literals are not requested" do
         it "should return a string" do
           # Should this de-duplicate?
-          expect(subject.get_values(RDF::Vocab::DC.title)).to eq ["test", "test"]
+          expect(subject.get_values(RDF::Vocab::DC.title))
+            .to contain_exactly "test", "test"
         end
       end
       context "and literals are requested" do
         it "should return literals" do
-          expect(subject.get_values(RDF::Vocab::DC.title, :literal => true)).to eq [literal1, literal2]
+          expect(subject.get_values(RDF::Vocab::DC.title, :literal => true))
+            .to contain_exactly literal1, literal2
         end
       end
     end
@@ -595,11 +604,13 @@ describe ActiveTriples::Resource do
     end
 
     it 'should return values for a predicate uri' do
-      expect(subject[RDF::Vocab::DC.title]).to eq ['Comet in Moominland', 'Finn Family Moomintroll']
+      expect(subject[RDF::Vocab::DC.title])
+        .to contain_exactly('Comet in Moominland', 'Finn Family Moomintroll')
     end
 
     it 'should return values for a registered predicate symbol' do
-      expect(subject[:title]).to eq ['Comet in Moominland', 'Finn Family Moomintroll']
+      expect(subject[:title])
+        .to contain_exactly('Comet in Moominland', 'Finn Family Moomintroll')
     end
 
     it "should return values for other subjects if asked" do
@@ -709,8 +720,11 @@ END
       document1.creator = [person1, person2]
       document2.creator = person1
       person1.knows = person2
+      person2.knows = person1
       subject.item = [document1]
-      expect(subject.item.first.creator.first.knows.first.foaf_name).to eq ['Bob']
+
+      expect(subject.item.first.creator.first.knows.first.foaf_name)
+        .to satisfy { |names| ['Alice', 'Bob'].include? names.first }
     end
   end
 
@@ -730,7 +744,7 @@ END
       it "should call prior to persisting" do
         expect(subject.title).to be_blank
         subject.persist!
-        expect(subject.title).to eq ["test"]
+        expect(subject.title).to contain_exactly "test"
       end
     end
   end


### PR DESCRIPTION
Changes `ActiveTriples::List#initialize` to match the base `RDF::List` version.

Adjusts order dependent tests. The default in-memory `RDF::Repository` implementation no longer preserves order. Note that this is not technically an interface change, since Repositories were never guaranteed or expected to be order preserving. Still, it is likely to
surprise some users who were using the previous (Ruby Hash based) in-memory Repository.