### PR TITLE
Patch AT for AF Support

### DIFF
--- a/active-triples.gemspec
+++ b/active-triples.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rdf',           '~> 2.0'
   s.add_dependency 'linkeddata',    '~> 2.0'
   s.add_dependency 'activemodel',   '>= 3.0.0'
-  s.add_dependency 'deprecation',   '~> 0.1'
+  s.add_dependency 'deprecation',   '~> 1.0'
   s.add_dependency 'activesupport', '>= 3.0.0'
 
   s.add_development_dependency 'rdoc'

--- a/lib/active_triples/persistence_strategies/parent_strategy.rb
+++ b/lib/active_triples/persistence_strategies/parent_strategy.rb
@@ -95,6 +95,7 @@ module ActiveTriples
     #
     # @return [true] true if the save did not error
     def persist!
+      return false if final_parent.frozen?
       erase_old_resource
       final_parent << source
       @persisted = true
@@ -105,6 +106,7 @@ module ActiveTriples
     #
     # @return [Boolean]
     def reload
+      return false if source.frozen?
       if loaded? || !persisted?
         source << final_parent.query(subject: source.rdf_subject)
       else

--- a/spec/active_triples/identifiable_spec.rb
+++ b/spec/active_triples/identifiable_spec.rb
@@ -155,5 +155,15 @@ describe ActiveTriples::Identifiable do
         expect(subject.rdf_subject).to eq 'http://example.org/ns/123'
       end
     end
+
+    describe "adding it as a property for an AT Resource" do
+      include_context 'with data'
+      it "returns the same in-memory object added" do
+        resource = MyResource.new
+        resource.relation = subject
+
+        expect(resource.relation).to eq [subject]
+      end
+    end
   end
 end


### PR DESCRIPTION
The big thing is when setting an identifiable object, it needs to cache the object and NOT the object's resource. I'm not sure this is the best way to do that, but it passes AF's tests. Basically - for identifiable objects maintain the old behavior of not duplicating the underlying resource.

Open to alternatives - but there needs to be a way for the instance that gets returned to be the same instance that was set.