### PR TITLE
Drop support for Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ script: "bundle exec rspec spec"
 sudo: false
 cache: bundler
 rvm:
- - 2.0
  - 2.1
  - 2.2.4
  - 2.3.1

--- a/active-triples.gemspec
+++ b/active-triples.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{RDF graphs in ActiveModel wrappers.}
   s.description = %q{ActiveTriples provides tools for modeling RDF as discrete resources.}
   s.license     = "APACHE2"
-  s.required_ruby_version     = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.1.0'
 
   s.add_dependency 'rdf',           '~> 2.0'
   s.add_dependency 'linkeddata',    '~> 2.0'


### PR DESCRIPTION
Ruby 2.0 was end-of-lifed this spring. We're dropping support for it here permanently.

See https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/