### PR TITLE
Force activesupport version in testing.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@ source "https://rubygems.org"
 
 gemspec
 
+gem 'activesupport', '< 5.0.0' if RUBY_VERSION =~ /2\.1\..*/
 gem 'pry-byebug' unless ENV["CI"]


### PR DESCRIPTION
This maintains Ruby 2.1 support by forcing CI to use a compatible version of `ActiveSupport`.