### PR TITLE
Feature/more perf refactors

### DIFF
--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -586,7 +586,12 @@ module ActiveTriples
         registered_preds = registered_predicates
         registered_preds << RDF.type
         unregistered_preds = []
-        each_statement { |s,p,o| unregistered_preds << p unless (s != rdf_subject) || (registered_preds.include? p) }
+        
+        query(subject: rdf_subject) do |stmt| 
+          unregistered_preds << stmt.predicate unless
+            registered_preds.include? stmt.predicate
+        end
+
         unregistered_preds
       end
 

--- a/spec/active_triples/resource_spec.rb
+++ b/spec/active_triples/resource_spec.rb
@@ -94,7 +94,7 @@ describe ActiveTriples::Resource do
 
       it 'should not be settable' do
         expect{ subject.set_subject! RDF::URI('http://example.org/moomin2') }
-          .to raise_error 'Refusing update URI when one is already assigned!'
+          .to raise_error 'Refusing to update URI when one is already assigned!'
       end
     end
 


### PR DESCRIPTION
In 4b19859:

`RDFSource#set_subject!` used to individually rewrite statements with
`#each_statement`, this meant touching every statement, even if none
would end up being rewritten. Additionally, it meant deleting and
inserting statements one at a time, even if the underlying repository
had a more efficient batch update.

This is replaced with a transaction over `#graph` and two queries.

The performance increase from this is theoretical, and not very likely
to play out in practice with the default `RDF::Repository`. This is true
for two reasons:

  - While query for the subject position will be much faster than doing
    `#each_statement` (subjects are a simple hash lookup), the `object`
    query will require a lookup on all subjects/predicate pairs. This is
    likely to have similar cost to simply iterating all the statements.

  - Bulk `#delete` and `#insert` run in linear time over the number of
    statements processed.

Still this is theoretically cleaner, and may show a benefit for other
in-memory backing repositories.

---
In 70240a9:

Only process statements with the correct subject in `#unregistered_predicates`. 

This should be a performance improvement for cases where multiple subjects are present in a graph (including BNodes). The query is more correct than iterating through all statements, and `subject` lookup in-particular is optimized on the in-memory repository.

---

The other two commits contain purely organizational refactors, documentation, and style fixes.