### PR TITLE
Upgrade to RDF.rb 2.0.2; Ruby 2.3.x compatibility

### DIFF
--- a/active-triples.gemspec
+++ b/active-triples.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = "APACHE2"
   s.required_ruby_version = '>= 2.1.0'
 
-  s.add_dependency 'rdf',           '~> 2.0'
+  s.add_dependency 'rdf',           '~> 2.0', '>= 2.0.2'
   s.add_dependency 'linkeddata',    '~> 2.0'
   s.add_dependency 'activemodel',   '>= 3.0.0'
   s.add_dependency 'deprecation',   '~> 0.1'


### PR DESCRIPTION
RDF.rb 2.0.2 fixes a bug that manifests in Ruby 2.3.0, affecting `RDF::List` comparisons we rely on.

See the release notes at https://github.com/ruby-rdf/rdf/releases/tag/2.0.2.