### PR TITLE
Feature/relation api

### DIFF
--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -23,6 +23,8 @@ module ActiveTriples
     include Enumerable
     include Comparable
 
+    TYPE_PROPERTY = { predicate: RDF.type, cast: false }.freeze
+
     # @!attribute [rw] parent
     #   @return [RDFSource] the resource that is the domain of this relation
     # @!attribute [rw] value_arguments
@@ -34,7 +36,7 @@ module ActiveTriples
     attr_accessor :parent, :value_arguments, :rel_args
     attr_reader :reflections
 
-    delegate :+, :<=>, :[], :empty?, :inspect, :last, :size, :join, :length, 
+    delegate :<=>, :+, :[], :empty?, :inspect, :last, :size, :join, :length, 
        :to => :to_a
 
     ##
@@ -362,7 +364,7 @@ module ActiveTriples
       # @private
       # @return [Hash<Symbol, ]
       def property_config
-        return type_property if is_type?
+        return TYPE_PROPERTY if is_type?
 
         reflections.reflect_on_property(property)
       end
@@ -379,12 +381,6 @@ module ActiveTriples
         resource = resource.to_uri if resource.respond_to? :to_uri
         raise ValueError, resource unless resource.kind_of? RDF::Term
         parent.insert [rdf_subject, predicate, resource]
-      end
-
-      ##
-      # @private
-      def type_property
-        { :predicate => RDF.type, :cast => false }
       end
 
       ##

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -36,7 +36,7 @@ module ActiveTriples
     attr_accessor :parent, :value_arguments, :rel_args
     attr_reader :reflections
 
-    delegate :+, :[], :inspect, :last, :size, :join, to: :to_a
+    delegate :[], :inspect, :last, :size, :join, to: :to_a
 
     ##
     # @param [ActiveTriples::RDFSource] parent_source
@@ -53,8 +53,50 @@ module ActiveTriples
     end
 
     ##
-    # Mimics `Set#<=>`, returning `0` when set membership is equivalent, and
-    # `nil` (as non-comparable) otherwise. Unlike `Set#<=>`, uses `#==` for
+    # @param array [#to_ary, ActiveTriples::Relation]
+    # @return [Array]
+    #
+    # @note simply passes to `Array#&` unless argument is a `Relation`
+    #
+    # @see Array#&
+    def &(array)
+      return to_a & array unless array.is_a? Relation
+
+      (objects.to_a & array.objects.to_a)
+        .map { |object| convert_object(object) }
+    end
+    
+    ##
+    # @param array [#to_ary, ActiveTriples::Relation]
+    # @return [Array]
+    #
+    # @note simply passes to `Array#|` unless argument is a `Relation`
+    #
+    # @see Array#|
+    def |(array)
+      return to_a | array unless array.is_a? Relation
+      
+      (objects.to_a | array.objects.to_a)
+        .map { |object| convert_object(object) }
+    end
+
+    ##
+    # @param array [#to_ary, ActiveTriples::Relation]
+    # @return [Array]
+    #
+    # @note simply passes to `Array#+` unless argument is a `Relation`
+    #
+    # @see Array#+
+    def +(array)
+      return to_a + array unless array.is_a? Relation
+
+      (objects.to_a + array.objects.to_a)
+        .map { |object| convert_object(object) }
+    end
+
+    ##
+    # Mimics `Set#<=>`, returning `0` when set membership is equivalent, and 
+    # `nil` (as non-comparable) otherwise. Unlike `Set#<=>`, uses `#==` for 
     # member comparisons.
     #
     # @param [Object] other

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -239,6 +239,18 @@ module ActiveTriples
     end
 
     ##
+    # @deprecated for removal in 1.0.0. Use `first || build({})`,
+    #   `build({}) if empty?` or similar logic.
+    #
+    # @return [Object] the first result, if present; else a newly built node
+    #
+    # @see #build
+    def first_or_create(attributes={})
+      warn 'DEPRECATION: #first_or_create is deprecated for removal in 1.0.0.'
+      first || build(attributes)
+    end
+
+    ##
     # Gives the predicate used by the Relation. Values of this object are
     # those that match the pattern `<rdf_subject> <predicate> [value] .`
     #

--- a/spec/active_triples/relation_spec.rb
+++ b/spec/active_triples/relation_spec.rb
@@ -221,7 +221,7 @@ describe ActiveTriples::Relation do
 
       it 'clears the relation' do
         expect { subject.clear }
-          .to change { subject.result }
+          .to change { subject.to_a }
           .from(['moomin']).to(be_empty)
       end
 
@@ -308,39 +308,12 @@ describe ActiveTriples::Relation do
     end
   end
 
-  describe '#first_or_create' do
-    let(:parent_resource) { ActiveTriples::Resource.new }
-
-    context 'with symbol' do
-      include_context 'with symbol property'
-
-      it 'creates a new node' do
-        expect { subject.first_or_create }.to change { subject.count }.by(1)
-      end
-
-      it 'returns existing node if present' do
-        node = subject.build
-        expect(subject.first_or_create).to eq node
-      end
-
-      it 'does not create a new node when one exists' do
-        subject.build
-        expect { subject.first_or_create }.not_to change { subject.count }
-      end
-
-      it 'returns literal value if appropriate' do
-        subject << literal = 'moomin'
-        expect(subject.first_or_create).to eq literal
-      end
-    end
-  end
-
   describe '#result' do
     context 'with nil predicate' do
       include_context 'with unregistered property'
 
       it 'is empty' do
-        expect(subject.result).to be_empty
+        expect(subject.send(:result)).to be_empty
       end
     end
 
@@ -350,7 +323,7 @@ describe ActiveTriples::Relation do
       end
 
       it 'is empty' do
-        expect(subject.result).to be_empty
+        expect(subject.send(:result)).to be_empty
       end
 
       context 'with values' do
@@ -364,7 +337,7 @@ describe ActiveTriples::Relation do
         let(:node)   { RDF::Node.new }
 
         it 'contain values' do
-          expect(subject.result).to contain_exactly(*values)
+          expect(subject.send(:result)).to contain_exactly(*values)
         end
 
         context 'with castable values' do
@@ -373,14 +346,14 @@ describe ActiveTriples::Relation do
           end
 
           it 'casts Resource values' do
-            expect(subject.result)
+            expect(subject.send(:result))
               .to contain_exactly(a_kind_of(ActiveTriples::Resource),
                                   a_kind_of(ActiveTriples::Resource),
                                   a_kind_of(ActiveTriples::Resource))
           end
 
           it 'cast values have correct URI' do
-            expect(subject.result.map(&:rdf_subject))
+            expect(subject.send(:result).map(&:rdf_subject))
               .to contain_exactly(*values)
           end
 
@@ -393,7 +366,7 @@ describe ActiveTriples::Relation do
             end
 
             it 'assigns persistence strategy' do
-              subject.result.each do |node|
+              subject.send(:result).each do |node|
                 expect(node.persistence_strategy)
                   .to be_a ActiveTriples::RepositoryStrategy
               end
@@ -408,7 +381,7 @@ describe ActiveTriples::Relation do
 
             it 'does not cast results' do
               allow(subject).to receive(:cast?).and_return(false)
-              expect(subject.result).to contain_exactly(*values)
+              expect(subject.send(:result)).to contain_exactly(*values)
             end
           end
 
@@ -420,7 +393,7 @@ describe ActiveTriples::Relation do
             it 'does not cast results' do
               allow(subject).to receive(:return_literals?).and_return(true)
 
-              expect(subject.result).to contain_exactly(*values)
+              expect(subject.send(:result)).to contain_exactly(*values)
             end
           end
         end

--- a/spec/active_triples/relation_spec.rb
+++ b/spec/active_triples/relation_spec.rb
@@ -308,12 +308,12 @@ describe ActiveTriples::Relation do
     end
   end
 
-  describe '#result' do
+  describe '#each' do
     context 'with nil predicate' do
       include_context 'with unregistered property'
 
       it 'is empty' do
-        expect(subject.send(:result)).to be_empty
+        expect(subject.each.to_a).to be_empty
       end
     end
 
@@ -323,7 +323,7 @@ describe ActiveTriples::Relation do
       end
 
       it 'is empty' do
-        expect(subject.send(:result)).to be_empty
+        expect(subject.each.to_a).to be_empty
       end
 
       context 'with values' do
@@ -337,7 +337,7 @@ describe ActiveTriples::Relation do
         let(:node)   { RDF::Node.new }
 
         it 'contain values' do
-          expect(subject.send(:result)).to contain_exactly(*values)
+          expect(subject.each).to contain_exactly(*values)
         end
 
         context 'with castable values' do
@@ -346,14 +346,14 @@ describe ActiveTriples::Relation do
           end
 
           it 'casts Resource values' do
-            expect(subject.send(:result))
+            expect(subject.each)
               .to contain_exactly(a_kind_of(ActiveTriples::Resource),
                                   a_kind_of(ActiveTriples::Resource),
                                   a_kind_of(ActiveTriples::Resource))
           end
 
           it 'cast values have correct URI' do
-            expect(subject.send(:result).map(&:rdf_subject))
+            expect(subject.each.map(&:rdf_subject))
               .to contain_exactly(*values)
           end
 
@@ -366,7 +366,7 @@ describe ActiveTriples::Relation do
             end
 
             it 'assigns persistence strategy' do
-              subject.send(:result).each do |node|
+              subject.each.each do |node|
                 expect(node.persistence_strategy)
                   .to be_a ActiveTriples::RepositoryStrategy
               end
@@ -381,7 +381,7 @@ describe ActiveTriples::Relation do
 
             it 'does not cast results' do
               allow(subject).to receive(:cast?).and_return(false)
-              expect(subject.send(:result)).to contain_exactly(*values)
+              expect(subject.each).to contain_exactly(*values)
             end
           end
 
@@ -393,7 +393,7 @@ describe ActiveTriples::Relation do
             it 'does not cast results' do
               allow(subject).to receive(:return_literals?).and_return(true)
 
-              expect(subject.send(:result)).to contain_exactly(*values)
+              expect(subject.each).to contain_exactly(*values)
             end
           end
         end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -13,3 +13,11 @@ RSpec::Matchers.define :be_a_relation_containing do |*expected|
   end
 end
 
+RSpec::Matchers.define :have_rdf_subject do |expected|
+  match do |actual|
+    expect(actual).to be_a ActiveTriples::RDFSource
+    expect(actual.to_term).to eq expected.to_term
+    true
+  end
+end
+


### PR DESCRIPTION
This is work toward #120.

The main work here is to remove `#result` in favor of `#each` and `Enumerable`. The API is now limited to:

```
#each (and Enumerable)
#<=> (and Comparable)
#<<
#build
#clear
#delete
#delete?
#predicate
#property
#set
#subtract
#swap
```

There's probably more that could be done to simplify.