### PR TITLE
Remove `@persisting` flag from `Persistable`

### DIFF
--- a/lib/active_triples/persistable.rb
+++ b/lib/active_triples/persistable.rb
@@ -77,19 +77,16 @@ module ActiveTriples
     end
 
     ##
-    # Sends a persistence message to the persistence_startegy, saving the
-    # RDFSource.
+    # Sends a persistence message to the `persistence_startegy`, saving the
+    # `Persistable`.
     #
     # @return [Boolean]
     def persist!(opts={})
-      return if @persisting
       result = false
       return result if opts[:validate] && !valid?
-      @persisting = true
       run_callbacks :persist do
         result = persistence_strategy.persist!
       end
-      @persisting = false
       result
     end
 

--- a/lib/active_triples/persistable.rb
+++ b/lib/active_triples/persistable.rb
@@ -27,13 +27,6 @@ module ActiveTriples
       persistence_strategy.graph
     end
 
-    ##
-    # @see RDF::Enumerable.each
-    def each(*args)
-      graph.each(*args)
-    end
-
-    ##
     # @see RDF::Writable.insert_statement
     def insert_statement(*args)
       graph.send(:insert_statement, *args)

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -385,7 +385,6 @@ module ActiveTriples
                 parent.persistence_strategy.ancestors.find { |a| a == new_resource })
           new_resource.set_persistence_strategy(ParentStrategy)
           new_resource.parent = parent
-          new_resource.persist!
         end
 
         self.node_cache[resource.rdf_subject] = (resource == object ? new_resource : object)


### PR DESCRIPTION
Closes #135.

This `@persisting` flag is meant to prevent looping calls to `#persist!` via callbacks. I don't know of a use case for it, and it seems like calling `#persist!` in a callback is a bug that should be rooted out.

I think @mjsuhonos is probably right in #135 that this is just unnecessary. We've really reduced the number of automatic`#persist!` calls, and I think we should continue to do so.

If someone has a counterexample, let's call attention to that and write some tests that fail on this branch.