### PR TITLE
Remove `linkeddata` dependency

### DIFF
--- a/active-triples.gemspec
+++ b/active-triples.gemspec
@@ -15,13 +15,16 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1.0'
 
   s.add_dependency 'rdf',           '~> 2.0', '>= 2.0.2'
-  s.add_dependency 'linkeddata',    '~> 2.0'
+  s.add_dependency 'rdf-vocab'
   s.add_dependency 'activemodel',   '>= 3.0.0'
   s.add_dependency 'activesupport', '>= 3.0.0'
 
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'rdf-spec', '~> 2.0'
+  s.add_development_dependency 'rdf-spec',   '~> 2.0'
+  s.add_development_dependency 'rdf-rdfxml', '~> 2.0'
+  s.add_development_dependency 'rdf-turtle', '~> 2.0'
+  s.add_development_dependency 'json-ld',    '~> 2.0'
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'nokogiri'

--- a/spec/active_triples/list_spec.rb
+++ b/spec/active_triples/list_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 require 'nokogiri'
-require 'linkeddata'
+require 'rdf/rdfxml'
 
 describe ActiveTriples::List do
   subject { ActiveTriples::List.new }


### PR DESCRIPTION
Don't assume clients will want the meta-distribution. Let them add the libraries individually.