### PR TITLE
Force bundler update before CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,9 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'activesupport', '< 5.0.0' if RUBY_VERSION =~ /2\.1\..*/
+if RUBY_VERSION =~ /2\.1\..*/
+  gem 'activesupport', '< 5.0.0' 
+  gem 'rdf-spec',      '< 2.0.3'
+end
+
 gem 'pry-byebug' unless ENV["CI"]

--- a/active-triples.gemspec
+++ b/active-triples.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1.0'
 
   s.add_dependency 'rdf',           '~> 2.0', '>= 2.0.2'
-  s.add_dependency 'rdf-vocab'
   s.add_dependency 'activemodel',   '>= 3.0.0'
   s.add_dependency 'activesupport', '>= 3.0.0'
 
@@ -24,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rdf-spec',   '~> 2.0'
   s.add_development_dependency 'rdf-rdfxml', '~> 2.0'
   s.add_development_dependency 'rdf-turtle', '~> 2.0'
+  s.add_development_dependency 'rdf-vocab'
   s.add_development_dependency 'json-ld',    '~> 2.0'
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'webmock'


### PR DESCRIPTION
Bundler 1.11 resolves dependencies by Ruby version. This is important.