### PR TITLE
Make `rdf-vocab` a development dependency

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,7 @@
+require 'simplecov'
+require 'coveralls'
+
+SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+SimpleCov.start do
+  add_filter 'spec'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,8 @@ source "https://rubygems.org"
 gemspec
 
 gem 'activesupport', '< 5.0.0' if RUBY_VERSION =~ /2\.1\..*/
+gem 'rdf-vocab',     '< 2.0.3' if RUBY_VERSION =~ /2\.1\..*/
+
+gem 'rspec'
+
 gem 'pry-byebug' unless ENV["CI"]

--- a/active-triples.gemspec
+++ b/active-triples.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1.0'
 
   s.add_dependency 'rdf',           '~> 2.0', '>= 2.0.2'
-  s.add_dependency 'rdf-vocab'
   s.add_dependency 'activemodel',   '>= 3.0.0'
   s.add_dependency 'activesupport', '>= 3.0.0'
 
@@ -24,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rdf-spec',   '~> 2.0'
   s.add_development_dependency 'rdf-rdfxml', '~> 2.0'
   s.add_development_dependency 'rdf-turtle', '~> 2.0'
+  s.add_development_dependency 'rdf-vocab'
   s.add_development_dependency 'json-ld',    '~> 2.0'
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'webmock'


### PR DESCRIPTION
We don't use `RDF::Vocab` except in tests. Presumably users will want it, but we don't need to push it on them.

Require `< 2.0.3` for Ruby 2.1.