### PR TITLE
Drop Ruby 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ script: "bundle exec rspec spec"
 sudo: false
 cache: bundler
 rvm:
- - 2.1
  - 2.2.4
  - 2.3.1
  - jruby-9.0.4.0


### PR DESCRIPTION
The [latest `rdf-vocab`](https://github.com/ruby-rdf/rdf-vocab/commit/42211658c50ee6d936263e845029a823178138c6) is causing trouble for dependency resolution on Ruby 2.1.

I just dropped the build; I'm leaving support in for now (not changing the `gemspec`), but will plan to drop it when 1.0 happens.