### PR TITLE
Use `RDF::URI#intern` to reduce allocation/gc

### DIFF
--- a/lib/active_triples/configurable.rb
+++ b/lib/active_triples/configurable.rb
@@ -62,7 +62,7 @@ module ActiveTriples
 
     def transform_type(values)
       Array.wrap(values).map do |value|
-        RDF::URI.new(value).tap do |uri|
+        RDF::URI.intern(value).tap do |uri|
           RDFSource.type_registry[uri] = self
         end
       end

--- a/lib/active_triples/property_builder.rb
+++ b/lib/active_triples/property_builder.rb
@@ -42,7 +42,7 @@ module ActiveTriples
       raise ArgumentError, "property names must be a Symbol" unless
         name.kind_of?(Symbol)
 
-      options[:predicate] = RDF::URI.new(options[:predicate])
+      options[:predicate] = RDF::URI.intern(options[:predicate])
       raise ArgumentError, "must provide an RDF::URI to :predicate" unless
         options[:predicate].valid?
 

--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -604,7 +604,7 @@ module ActiveTriples
       return uri_or_node if uri_or_node.valid?
 
       uri_or_str = uri_or_str.to_s
-      return RDF::URI(base_uri.to_s) / uri_or_str if
+      return RDF::URI.intern(base_uri.to_s) / uri_or_str if
         base_uri && !uri_or_str.start_with?(base_uri.to_s)
 
       raise "could not make a valid RDF::URI from #{uri_or_str}"
@@ -649,6 +649,7 @@ module ActiveTriples
       #          a window of opportunity for an ID clash.
       def id_persisted?(test_id)
         rdf_subject = new(test_id).rdf_subject
+
         ActiveTriples::Repositories.has_subject?(rdf_subject)
       end
 
@@ -664,8 +665,9 @@ module ActiveTriples
       #          persisted, false will be returned presenting
       #          a window of opportunity for an ID clash.
       def uri_persisted?(test_uri)
-        rdf_subject = test_uri.is_a?(RDF::URI) ? test_uri : RDF::URI(test_uri)
-        ActiveTriples::Repositories.has_subject?(rdf_subject)
+        test_uri = RDF::URI.intern(test_uri) unless test_uri.is_a?(RDF::URI)
+
+        ActiveTriples::Repositories.has_subject?(test_uri)
       end
     end
   end

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -587,7 +587,7 @@ module ActiveTriples
       ##
       # @private
       def uri_class(v)
-        v = RDF::URI.new(v) if v.kind_of? String
+        v = RDF::URI.intern(v) if v.kind_of? String
         type_uri = parent.query([v, RDF.type, nil]).to_a.first.try(:object)
         Resource.type_registry[type_uri]
       end


### PR DESCRIPTION
`#intern` caches URIs to avoid frequent allocation/gc cycles on commonly used terms. Specifically, we intern base, subject, type, and predicate URIs.