### PR TITLE
Remove `linkeddata` dependency

### DIFF
--- a/active-triples.gemspec
+++ b/active-triples.gemspec
@@ -15,13 +15,16 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = '>= 1.9.3'
   
   s.add_dependency('rdf', '~> 1.1')
-  s.add_dependency('linkeddata', '~> 1.1')
   s.add_dependency('activemodel', '>= 3.0.0')
   s.add_dependency('deprecation', '~> 1.0')
   s.add_dependency('activesupport', '>= 3.0.0')
 
   s.add_development_dependency('rdoc')
   s.add_development_dependency('rspec')
+  s.add_development_dependency('rdf-rdfxml', '~> 1.99')
+  s.add_development_dependency('rdf-turtle', '~> 1.99')
+  s.add_development_dependency('json-ld', '~> 1.99')
+  s.add_development_dependency('rdf-isomorphic', '~> 1.99')
   s.add_development_dependency('coveralls')
   s.add_development_dependency('guard-rspec') unless ENV['CI']
   s.add_development_dependency('webmock')

--- a/spec/active_triples/list_spec.rb
+++ b/spec/active_triples/list_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 require 'nokogiri'
-require 'linkeddata'
+require 'rdf/rdfxml'
 
 describe ActiveTriples::List do
 

--- a/spec/pragmatic_context_spec.rb
+++ b/spec/pragmatic_context_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'pragmatic_context'
+require 'json/ld'
 
 describe 'PragmaticContext integration' do
   before do


### PR DESCRIPTION
Don't assume clients will want the meta-distribution. Let them add the
libraries individually.
