### PR TITLE
Rework literal handling in `Relation`

### DIFF
--- a/spec/active_triples/identifiable_spec.rb
+++ b/spec/active_triples/identifiable_spec.rb
@@ -168,6 +168,15 @@ describe ActiveTriples::Identifiable do
 
         expect(resource.relation).to eq [subject]
       end
+      it "can share that object with another resource" do
+        resource = MyResource.new
+        resource_2 = MyResource.new
+
+        resource.relation = subject
+        resource_2.relation = resource.relation
+
+        expect(resource.relation).to eq resource_2.relation
+      end
     end
   end
 end

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -341,15 +341,6 @@ describe ActiveTriples::RDFSource do
       expect(subject.get_values(other_uri, predicate))
         .to be_a_relation_containing(val)
     end
-
-    context 'when calling getter' do
-      it 'passes arguments through' do
-        subject.creator = 'moomin'
-
-        expect(subject.creator(literal: true).first)
-          .to eq RDF::Literal('moomin')
-      end
-    end
   end
 
   describe '#set_value' do
@@ -529,28 +520,43 @@ describe ActiveTriples::RDFSource do
     end
 
     describe 'capturing child nodes' do
-      let(:other) { source_class.new }
+      let(:other)     { source_class.new }
+      let(:predicate) { RDF::OWL.sameAs }
 
       it 'adds child node data to own graph' do
         other << RDF::Statement(:s, RDF::URI('p'), 'o')
 
-        expect { subject.set_value(RDF::OWL.sameAs, other) }
+        expect { subject.set_value(predicate, other) }
           .to change { subject.statements.to_a }
           .to include(*other.statements.to_a)
       end
 
       it 'does not change persistence strategy of added node' do
-        expect { subject.set_value(RDF::OWL.sameAs, other) }
+        expect { subject.set_value(predicate, other) }
           .not_to change { other.persistence_strategy }
       end
 
       it 'does not capture a child node when it already persists to a parent' do
         third = source_class.new
-        third.set_value(RDF::OWL.sameAs, other)
+        third.set_value(predicate, other)
 
-        child_other = third.get_values(RDF::OWL.sameAs).first
-        expect { subject.set_value(RDF::OWL.sameAs, child_other) }
+        child_other = third.get_values(predicate).first
+        expect { subject.set_value(predicate, child_other) }
           .not_to change { child_other.persistence_strategy.parent }
+      end
+      
+      context 'when setting to a relation' do
+        it 'adds child node data to graph' do
+          other << RDF::Statement(other, RDF::URI('p'), 'o')
+          
+          relation_source = source_class.new 
+          relation_source.set_value(predicate, other)
+          relation = relation_source.get_values(predicate)
+          
+          expect { subject.set_value(predicate, relation) }
+            .to change { subject.statements.to_a }
+            .to include(*other.statements.to_a)
+        end
       end
     end
   end

--- a/spec/active_triples/resource_spec.rb
+++ b/spec/active_triples/resource_spec.rb
@@ -571,21 +571,14 @@ describe ActiveTriples::Resource do
     context "literals are set" do
       let(:literal1) { RDF::Literal.new("test", :language => :en) }
       let(:literal2) { RDF::Literal.new("test", :language => :fr) }
+
       before do
         subject.set_value(RDF::Vocab::DC.title, [literal1, literal2])
       end
-      context "and literals are not requested" do
-        it "should return a string" do
-          # Should this de-duplicate?
-          expect(subject.get_values(RDF::Vocab::DC.title))
-            .to contain_exactly "test", "test"
-        end
-      end
-      context "and literals are requested" do
-        it "should return literals" do
-          expect(subject.get_values(RDF::Vocab::DC.title, :literal => true))
-            .to contain_exactly literal1, literal2
-        end
+
+      it "should return literals" do
+        expect(subject.get_values(RDF::Vocab::DC.title, :literal => true))
+          .to contain_exactly literal1, literal2
       end
     end
   end


### PR DESCRIPTION
Reworks the default handling of `Relation` literal values:

  - Plain `xsd:String` literals are Ruby Strings;
  - `rdf:langString` literals are returned as `RDF::Literal` objects;
  - Known datatypes are cast to `#object` for best effort native Ruby support;
    - A datatype is "known" if a class exists that subclasses `RDF::Literal` and has the datatype URI as its `DATATYPE` constant.
  - Unknown datatypes are returned as `RDF::Literal` objects.

When setting values from a Relation, always uses the `Literal`
value (through `Relation#objects`) to avoid losing data. URIs and blank
nods are still cast to their cached `RDFSource` versions.

Removes `literal: true` as a relation option.

Fixes the bug in #245 causing literal languages to be lost when setting
values to an existing `Relation` (including self).