### PR TITLE
Return all `<s> <p> ?o` patterns in Relation

### DIFF
--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -571,7 +571,6 @@ module ActiveTriples
         node ||= klass.from_uri(value,parent)
         node.set_persistence_strategy(property_config[:persist_to]) if
           is_property? && property_config[:persist_to]
-        return nil if (is_property? && property_config[:class_name]) && (class_for_value(value) != class_for_property)
 
         self.node_cache[value] ||= node
       end

--- a/spec/active_triples/relation_spec.rb
+++ b/spec/active_triples/relation_spec.rb
@@ -652,6 +652,45 @@ describe ActiveTriples::Relation do
             expect(subject.each.map(&:rdf_subject))
               .to contain_exactly(*values)
           end
+          
+          context 'and a class is configured' do
+            let(:this_type) { RDF::URI('http://example.org/Moomin') }
+            let(:this_class) do
+              Class.new do
+                include ActiveTriples::RDFSource
+                configure type: RDF::URI('http://example.org/Moomin')
+              end
+            end
+
+            let(:other_type) { RDF::URI('http://example.org/Snork') }
+            let(:other_class) do
+              Class.new do
+                include ActiveTriples::RDFSource
+                configure type: RDF::URI('http://example.org/Snork')
+              end
+            end
+
+            before do
+              reflections
+                .property property,
+                          class_name: this_class,
+                          predicate:  RDF::URI('http://example.org/moomin')
+            end
+              
+            it 'casts values with no type to the class' do
+              expect(subject).to contain_exactly(an_instance_of(this_class), 
+                                                 an_instance_of(this_class),
+                                                 an_instance_of(this_class))
+            end
+
+            it 'casts values with other type to the other class' do
+              subject << other_class.new
+              expect(subject).to contain_exactly(an_instance_of(this_class), 
+                                                 an_instance_of(this_class),
+                                                 an_instance_of(this_class),
+                                                 an_instance_of(other_class))
+            end
+          end
 
           context 'and persistence_strategy is configured' do
             before do


### PR DESCRIPTION
Regardless of type/class of the object, return the value. Cast to the configured class by default. On type conflicts, cast to the specified type.

ce96ad9 contains some cleanup of the `#make_node` behavior, encountered while testing this.

Closes #43 
