### PR TITLE
Add RDFSource#inspect

### DIFF
--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -288,6 +288,14 @@ module ActiveTriples
     end
 
     ##
+    # @return [String]
+    #
+    # @note Without a custom #inspect, we inherit from RDF::Value.
+    def inspect
+      sprintf("#<%s:%#0x ID:%s>", self.class.to_s, self.object_id, self.to_base)
+    end
+
+    ##
     # @return [Boolean] true if the Term is a node
     #
     # @see RDF::Term#node?
@@ -493,7 +501,7 @@ module ActiveTriples
     end
 
     ##
-    # @deprecated for removal in 1.0; use `#get_values` instead.
+    # @deprecated for removal in 1.0; use `#get_values` insctead.
     # @see #get_values
     def get_relation(args)
       warn 'DEPRECATION: `ActiveTriples::RDFSource#get_relation` will be' \

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -272,6 +272,18 @@ describe ActiveTriples::RDFSource do
     end
   end
 
+  describe '#inspect' do
+    it 'includes bnode id' do
+      expect(subject.inspect).to include subject.to_base
+    end
+
+    it 'includes uri' do
+      subject.set_subject!('http://example.org/moomin')
+
+      expect(subject.inspect).to include subject.to_base
+    end
+  end
+
   describe '#rdf_subject' do
     its(:rdf_subject) { is_expected.to be_a_node }
 


### PR DESCRIPTION
RDFSource previously inherited #inspect from RDF::Value. This new version is nicer looking, and actually contains the URI or BNode ID.