### PR TITLE
Allow config blocks in `ActiveTriples::Schema`

### DIFF
--- a/lib/active_triples/extension_strategy.rb
+++ b/lib/active_triples/extension_strategy.rb
@@ -10,7 +10,7 @@ module ActiveTriples
       #   the property to.
       # @param [ActiveTriples::Property] property The property to copy.
       def apply(resource, property)
-        resource.property property.name, property.to_h
+        resource.property(property.name, property.to_h, &property.config)
       end
     end
   end

--- a/lib/active_triples/property.rb
+++ b/lib/active_triples/property.rb
@@ -14,15 +14,18 @@ module ActiveTriples
     # @option options [Boolean] :cast
     # @option options [String, Class] :class_name
     # @option options [RDF::URI] :predicate
-    def initialize(options = {})
-      self.name = options.fetch(:name)
+    def initialize(options = {}, &block)
+      self.name       = options.fetch(:name)
       self.attributes = options.except(:name)
+      self.config     = block 
     end
 
     ##
     # @!attribute [r] name
     #   @return [Symbol]
-    attr_reader :name
+    # @!attribute [r] config
+    #   @return [Proc]
+    attr_reader :name, :config
 
     ##
     # @return [Boolean]
@@ -47,9 +50,11 @@ module ActiveTriples
     ##
     # @!attribute [w] name
     #   @return [Symbol]
+    # @!attribute [w] config
+    #   @return [Proc]
     # @!attribute [rw] attributes
     #   @return [Hash<Symbol, Object>]
-    attr_writer   :name
+    attr_writer   :name, :config
     attr_accessor :attributes
 
     alias_method :to_h, :attributes

--- a/spec/active_triples/extension_strategy_spec.rb
+++ b/spec/active_triples/extension_strategy_spec.rb
@@ -14,14 +14,25 @@ RSpec.describe ActiveTriples::ExtensionStrategy do
       expect(asset).to have_received(:property).with(property.name, property.to_h)
     end
 
+    it 'execute the block' do
+      block = Proc.new {}
+      asset = build_asset
+      property = build_property("name", {:predicate => RDF::Vocab::DC.title}, &block)
+
+      subject.apply(asset, property)
+
+      expect(asset).to have_received(:property).with(property.name, property.to_h, &block)
+    end
+
     def build_asset
       object_double(ActiveTriples::Resource, :property => nil)
     end
 
-    def build_property(name, options)
+    def build_property(name, options, &block)
       property = object_double(ActiveTriples::Property.new(:name => nil))
       allow(property).to receive(:name).and_return(name)
       allow(property).to receive(:to_h).and_return(options)
+      allow(property).to receive(:config).and_return(block)
       property
     end
   end

--- a/spec/active_triples/property_spec.rb
+++ b/spec/active_triples/property_spec.rb
@@ -17,6 +17,16 @@ describe ActiveTriples::Property do
     expect(subject.class_name).to eq "Test"
   end
 
+  it 'should hold a block' do
+    fake = Object.new
+    property = described_class.new(options) do
+      fake.configure
+    end
+
+    expect(fake).to receive(:configure)
+    property.config.call
+  end
+
   describe "#to_h" do
     it "should not return the property's name" do
       expect(subject.to_h).to eq (

--- a/spec/active_triples/schema_spec.rb
+++ b/spec/active_triples/schema_spec.rb
@@ -12,5 +12,11 @@ RSpec.describe ActiveTriples::Schema do
       expect(property.name).to eq :title
       expect(property.predicate).to eq RDF::Vocab::DC.title
     end
+
+    it 'should hold a block' do
+      subject.property :title, :predicate => RDF::Vocab::DC.title do
+        configure
+      end
+    end
   end
 end


### PR DESCRIPTION
Blocks like the following are used in `NodeConfig` for extensible configuration.

  Property.new(name, options) do |index|
    index.as :blah
  end

`ActiveTriples::Schema` previously ignored these kinds of configurations. This allows arbitrary blocks to be used in schema.