### PR TITLE
Adds a callback mechanism for observing mutation of relations

### DIFF
--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -389,6 +389,7 @@ module ActiveTriples
 
       values = prepare_relation(values) if values.is_a?(Relation)
       values = [values].compact unless values.kind_of?(Array)
+      parent.property_will_change(property, values)
 
       clear
       values.each { |val| set_value(val) }

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -173,9 +173,9 @@ describe ActiveTriples::RDFSource do
 
     context 'with statements for other subjects' do
       before do
-        subject << 
+        subject <<
           RDF::Statement(RDF::URI('http://example.org/OTHER_SUBJECT'),
-                         RDF::URI('http://example.org/ontology/OTHER_PRED'), 
+                         RDF::URI('http://example.org/ontology/OTHER_PRED'),
                          'OTHER_OBJECT')
       end
 
@@ -490,14 +490,14 @@ describe ActiveTriples::RDFSource do
     describe 'on child nodes' do
       let(:parent)  { source_class.new }
       let(:subject) { source_class.new(uri, parent) }
-      
+
       include_examples 'setting values' do
         let(:value) do
-          ['moomin', 
-           Date.today, 
-           RDF::Node.new, 
-           source_class.new, 
-           source_class.new(uri / 'new'), 
+          ['moomin',
+           Date.today,
+           RDF::Node.new,
+           source_class.new,
+           source_class.new(uri / 'new'),
            subject]
         end
       end
@@ -511,7 +511,7 @@ describe ActiveTriples::RDFSource do
 
       it 'persists to parent' do
         property = RDF::Vocab::DC.title
-        
+
         subject.set_value(property, 'Comet in Moominland')
 
         expect { subject.persist! }
@@ -597,15 +597,15 @@ describe ActiveTriples::RDFSource do
         expect { subject.set_value(predicate, child_other) }
           .not_to change { child_other.persistence_strategy.parent }
       end
-      
+
       context 'when setting to a relation' do
         it 'adds child node data to graph' do
           other << RDF::Statement(other, RDF::URI('p'), 'o')
-          
-          relation_source = source_class.new 
+
+          relation_source = source_class.new
           relation_source.set_value(predicate, other)
           relation = relation_source.get_values(predicate)
-          
+
           expect { subject.set_value(predicate, relation) }
             .to change { subject.statements.to_a }
             .to include(*other.statements.to_a)
@@ -718,6 +718,24 @@ describe ActiveTriples::RDFSource do
       dummy_source.apply_schema MyDataModel
 
       expect { dummy_source.new.test_title }.not_to raise_error
+    end
+  end
+
+  describe 'callback' do
+    let(:callback) {double}
+
+    before do
+      class TestRdfSource
+        include ActiveTriples::RDFSource
+        property :test_title, predicate: RDF::Vocab::DC.title
+      end
+    end
+
+    it 'should be invoked when a property changes' do
+      expect(callback).to receive(:call).with(:test_title, ["A Title"])
+
+      rdf_source = TestRdfSource.new(callback: callback)
+      rdf_source[:test_title] = "A Title"
     end
   end
 end

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -721,20 +721,19 @@ describe ActiveTriples::RDFSource do
     end
   end
 
-  describe 'callback' do
+  describe 'on_property_change callback' do
     let(:callback) {double}
-
-    before do
-      class TestRdfSource
+    let(:dummy_class) do
+      Class.new do
         include ActiveTriples::RDFSource
         property :test_title, predicate: RDF::Vocab::DC.title
       end
     end
 
-    it 'should be invoked when a property changes' do
+    it 'is invoked when a property changes' do
       expect(callback).to receive(:call).with(:test_title, ["A Title"])
 
-      rdf_source = TestRdfSource.new(callback: callback)
+      rdf_source = dummy_class.new(on_property_change: callback)
       rdf_source[:test_title] = "A Title"
     end
   end


### PR DESCRIPTION
The concrete use-case for this is allowing ActiveFedora to be aware of when properties become dirty in more cases than it previously could (specifically, this allows it to detect when values are <<'d onto a relation and persist the changes properly, addressing a long-standing bug/PITA). A PR has been opened ActiveFedora to take advantage of this.

(I'm just kind of guessing that develop is the correct branch to PR against?)