### PR TITLE
Add observers to `RDFSource`

### DIFF
--- a/lib/active_triples/rdf_source.rb
+++ b/lib/active_triples/rdf_source.rb
@@ -572,11 +572,32 @@ module ActiveTriples
     end
 
     ##
+    # Sends `#notify` messages with the property symbol and the current values
+    # for the property to each observer.
+    #
+    # @note We short circuit to avoid query costs if no observers are present.
+    #   If there are regisetred observers, values are returned as an array.
+    #   This means that we incur query costs immediately and only once.
+    #
+    # @example Setting up observers
+    #    class MyObserver
+    #      def notify(property, values)
+    #        # do something
+    #      end
+    #    end
+    #
+    #    observer = MyObserver.new
+    #    my_source.add_observer(observer)
+    #
+    #    my_source.creator = 'Moomin'
+    #    # the observer recieves a #notify(:creator, ['Moomin']) message here.
+    #
     # @param property [Symbol]
-    # @param values   [Enumerator]
     #
     # @return [void]
-    def notify_observers(property, values)
+    def notify_observers(property)
+      return if @observers.empty?
+      values = get_values(property).to_a
       @observers.each { |o| o.notify(property, values) }
     end
 

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -390,6 +390,7 @@ module ActiveTriples
       values = prepare_relation(values) if values.is_a?(Relation)
       values = [values].compact unless values.kind_of?(Array)
 
+      parent.notify_observers(property, values)
       clear
       values.each { |val| set_value(val) }
       

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -212,7 +212,7 @@ module ActiveTriples
     def clear
       return self if empty?
       parent.delete([rdf_subject, predicate, nil])
-      parent.notify_observers(property, self)
+      parent.notify_observers(property)
 
       self
     end
@@ -251,7 +251,7 @@ module ActiveTriples
       return self if parent.query([rdf_subject, predicate, value]).nil?
 
       parent.delete([rdf_subject, predicate, value])
-      parent.notify_observers(property, self)
+      parent.notify_observers(property)
       self
     end
 
@@ -397,7 +397,7 @@ module ActiveTriples
 
       clear
       values.each { |val| set_value(val) }
-      parent.notify_observers(property, self)
+      parent.notify_observers(property)
       
       parent.persist! if parent.persistence_strategy.respond_to?(:ancestors) &&
                          parent.persistence_strategy.ancestors.any? { |r| r.is_a?(ActiveTriples::List::ListResource) }
@@ -429,7 +429,7 @@ module ActiveTriples
       end
 
       parent.delete(*statements)
-      parent.notify_observers(property, self)
+      parent.notify_observers(property)
       self
     end
 

--- a/lib/active_triples/relation.rb
+++ b/lib/active_triples/relation.rb
@@ -395,9 +395,9 @@ module ActiveTriples
       values = prepare_relation(values) if values.is_a?(Relation)
       values = [values].compact unless values.kind_of?(Array)
 
-      parent.notify_observers(property, values)
       clear
       values.each { |val| set_value(val) }
+      parent.notify_observers(property, self)
       
       parent.persist! if parent.persistence_strategy.respond_to?(:ancestors) &&
                          parent.persistence_strategy.ancestors.any? { |r| r.is_a?(ActiveTriples::List::ListResource) }

--- a/spec/active_triples/rdf_source_spec.rb
+++ b/spec/active_triples/rdf_source_spec.rb
@@ -108,6 +108,45 @@ describe ActiveTriples::RDFSource do
     end
   end
 
+  describe 'observers' do
+    let(:observer) { double('observer') }
+
+    before { subject.add_observer(observer) }
+
+    include_context 'with properties'
+    
+    it 'notifies an observer of changes' do
+      expect(observer)
+        .to receive(:notify)
+        .with(:creator, a_collection_containing_exactly('moomin'))
+
+      subject.creator = 'moomin'
+    end
+
+    it 'notifies muliple observers of changes' do
+      other_observer = double('second observer')
+      values         = ['moomin', 'snork']
+
+      expect(observer)
+        .to receive(:notify)
+        .with(:creator, a_collection_containing_exactly(*values))
+      expect(other_observer)
+        .to receive(:notify)
+        .with(:creator, a_collection_containing_exactly(*values))
+
+      subject.add_observer(other_observer)
+      subject.creator = values
+    end
+
+    it 'does not notify removed observers' do
+      expect(observer).not_to receive(:notify)
+      
+      subject.delete_observer(observer)
+
+      subject.creator = 'moomin'
+    end
+  end
+
   describe '#==' do
     shared_examples 'Term equality' do
       it 'equals itself' do


### PR DESCRIPTION
RDFSources now notify observers of changes.

This is an alternate implementation for #258.