### PR TITLE
Test, document, and add deprecatitons for NodeConfig

### DIFF
--- a/lib/active_triples/node_config.rb
+++ b/lib/active_triples/node_config.rb
@@ -1,20 +1,48 @@
 # frozen_string_literal: true
+
 module ActiveTriples
+  ##
+  # Configuration for properties
   class NodeConfig
+    ##
+    # @!attribute class_name [rw]
+    #   @return [Class, String]
+    # @!attribute predicate [rw]
+    #   @return [RDF::URI]
+    # @!attribute term [rw]
+    #   @return [Symbol]
+    # @!attribute type [rw]
+    #   @return [Symbol]
+    # @!attribute behaviors [rw]
+    #   @return [Enumerator<Symbol>]
+    # @!attribute cast [rw]
+    #   @return [Boolean]
     attr_accessor :predicate, :term, :class_name, :type, :behaviors, :cast
 
-    def initialize(term, predicate, args={})
+    ##
+    # @param  term      [Symbol]
+    # @param  predicate [RDF::URI]
+    # @param  opts      [Hash<Symbol, Object>]
+    # @option opts      [String, Class] :class_name
+    # @option opts      [String, Class] :class_name
+    #
+    # @yield yields self to the block
+    # @yieldparam config [NodeConfig] self
+    def initialize(term, predicate, opts={})
       self.term = term
       self.predicate = predicate
-      self.class_name = args.delete(:class_name) { default_class_name }
-      self.cast = args.delete(:cast) { true }
-      @opts = args
+      self.class_name = opts.delete(:class_name) { nil }
+      self.cast = opts.delete(:cast) { true }
+      @opts = opts
       yield(self) if block_given?
     end
 
+    ##
+    # @param value [#to_sym]
+    # @return [Object] the attribute or option represented by the symbol
     def [](value)
       value = value.to_sym
-      self.respond_to?(value) ? self.send(value) : @opts[value]
+      self.respond_to?(value) ? self.public_send(value) : @opts[value]
     end
 
     def class_name
@@ -30,7 +58,10 @@ module ActiveTriples
       @class_name
     end
 
-    def with_index (&block)
+    ##
+    # @yield yields an index configuration object
+    # @yieldparam index [NodeConfig::IndexObject]
+    def with_index(&block)
       # needed for solrizer integration
       iobj = IndexObject.new
       yield iobj
@@ -40,27 +71,52 @@ module ActiveTriples
 
     private
 
+    ##
+    # @deprecated Use `nil` instead.
     def default_class_name
+        warn 'DEPRECATION: `ActiveTriples::NodeConfig#default_class_name` ' \
+             'will be removed in 1.0. Use `nil`.'
       nil
     end
 
     # this enables a cleaner API for solr integration
     class IndexObject
+      ##
+      # @!attribute data_type [rw]
+      #   @return [Symbol]
+      # @!attribute behaviors [rw]
+      #   @return [Enumerator<Symbol>]
       attr_accessor :data_type, :behaviors
+
       def initialize
         @behaviors = []
         @data_type = :string
       end
+
+      ##
+      # @param [Array<Symbol>] *args Behaviors for this index object
+      #
+      # @return [Array<Symbol>]
       def as(*args)
         @behaviors = args
       end
+
+      ##
+      # @param sym [Symbol]
       def type(sym)
         @data_type = sym
       end
-      def defaults
+
+      ##
+      # @deprecated Omit calls to this method; it has always been a no-op.
+      #
+      # @return [Symbol] :noop
+      def defaults # no-op
+        warn 'DEPRECATION: `ActiveTriples::NodeConfig::IndexObject#defaults` ' \
+             'will be removed in 1.0. If you are doing `index.defaults` in a ' \
+             'property config block, you can simply omit the call.'
         :noop
       end
     end
   end
 end
-

--- a/spec/active_triples/node_config_spec.rb
+++ b/spec/active_triples/node_config_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe ActiveTriples::NodeConfig do
+  subject(:config) { described_class.new(term, predicate) }
+  let(:predicate)  { RDF::URI(nil) }
+  let(:term)       { :moomin }
+
+  it { is_expected.to have_attributes(predicate: predicate, term: term) }
+
+  describe '#[]' do
+    subject(:config) { described_class.new(term, predicate, some_opt: :moomin) }
+
+    it 'accesses arbitrary opts' do
+      expect(config[:some_opt]).to eq :moomin
+    end
+  end
+
+  describe '#cast' do
+    it 'defaults to true' do
+      expect { config.cast = false }
+        .to change { config.cast }
+        .from(true)
+        .to(false)
+    end
+
+    it 'is set with the initializer' do
+      expect(described_class.new(term, predicate, cast: false).cast).to be false
+    end
+  end
+
+  describe '#with_index' do
+    it 'yields an index configuration object' do
+      expect { |b| config.with_index(&b) }
+        .to yield_with_args(an_instance_of(described_class::IndexObject))
+    end
+
+    it 'accepts behavior settings' do
+      config.with_index do |index|
+        index.as :moomin, :snork
+      end
+
+      expect(config.behaviors).to contain_exactly :moomin, :snork
+    end
+
+    it 'accepts type settings' do
+      config.with_index do |index|
+        index.type :moomin
+      end
+
+      expect(config.type).to eq :moomin
+    end
+  end
+end


### PR DESCRIPTION
`NodeConfig` was one of the few remaining classes without unit tests. This begins by testing mostly uncovered code and adds documentation. Some deprecations and style cleanup are also added.