### PR TITLE
More tweaks to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ rvm:
  - 2.3
  - 2.4
  - ruby-head
- - jruby
- - rbx
+ - jruby-9.1.9.0
+ - jruby-head
 matrix:
   allow_failures:
-      - rvm: jruby
-      - rvm: rbx
+      - rvm: jruby-9.1.9.0
+      - rvm: jruby-head
       - rvm: ruby-head


### PR DESCRIPTION
Remove rbx (we don't care anymore), and fix jruby builds.