### PR TITLE
Avoid infinite loop

### DIFF
--- a/lib/active_triples/persistence_strategies/parent_strategy.rb
+++ b/lib/active_triples/persistence_strategies/parent_strategy.rb
@@ -124,7 +124,7 @@ module ActiveTriples
     def reload
       return false if source.frozen?
 
-      final_parent.persistence_strategy.class.new(source).reload
+      final_parent.persistence_strategy.class.new(source).reload unless final_parent == parent
       self.graph = source.to_a
 
       @persisted = true unless graph.empty?


### PR DESCRIPTION
In my Hyrax app, if I set a property's value to an RDF::URI via the dynamically defined setter and then try to retrieve it via the getter I run into a stack level too deep when it tries to cast it.  I tracked it down to this change.